### PR TITLE
docs: update clone URL and fix relative directory navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ Every photo captured solves real problems:
 
 ```bash
 cd ~
-git clone https://github.com/mbcse/lensmint-camera.git lensmint
+git clone https://github.com/c2siorg/lensmint-camera.git lensmint
 cd lensmint
 ```
 

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ Every photo captured solves real problems:
 
 ```bash
 cd ~
-git clone <repository-url> lensmint
+git clone https://github.com/mbcse/lensmint-camera.git lensmint
 cd lensmint
 ```
 
@@ -779,7 +779,7 @@ Create `.env` files in `hardware-web3-service` and `lensmint-public-server` dire
 ### Step 7: Initialize Hardware Identity
 
 ```bash
-cd hardware-camera-app
+cd ../hardware-camera-app
 python3 hardware_identity.py
 ```
 
@@ -788,7 +788,7 @@ python3 hardware_identity.py
 ```bash
 sudo npm install -g pm2
 
-cd hardware-web3-service
+cd ../hardware-web3-service
 pm2 start server.js --name lensmint-hardware-web3-service
 
 cd ../lensmint-public-server
@@ -801,7 +801,7 @@ pm2 startup
 ### Step 9: Start Camera App
 
 ```bash
-cd hardware-camera-app
+cd ../hardware-camera-app
 source venv/bin/activate
 python3 raspberry_pi_camera_app.py
 ```
@@ -811,7 +811,7 @@ python3 raspberry_pi_camera_app.py
 For owner wallet management with Privy integration:
 
 ```bash
-cd owner-portal
+cd ../owner-portal
 npm install
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
-pip install kivy[base] pillow numpy opencv-python requests qrcode[pil]
+pip install kivy[base] pillow numpy opencv-python requests qrcode[pil] ecdsa
 ```
 
 ### Step 4: Install Hardware Web3 Service Dependencies
@@ -779,7 +779,7 @@ Create `.env` files in `hardware-web3-service` and `lensmint-public-server` dire
 ### Step 7: Initialize Hardware Identity
 
 ```bash
-cd ../hardware-camera-app
+cd hardware-camera-app
 python3 hardware_identity.py
 ```
 


### PR DESCRIPTION
Replaced the <repository-url> placeholder with the actual GitHub URL in the git clone instructions.
Updated sequential cd commands across the installation steps (e.g., cd ../hardware-camera-app, cd ../hardware-web3-service) to use relative paths, preventing users from encountering "directory not found" errors while following the setup steps.