### PR TITLE
fix: prevent double-minting race condition in edition requests

### DIFF
--- a/hardware-web3-service/server.js
+++ b/hardware-web3-service/server.js
@@ -195,7 +195,10 @@ function startClaimPolling() {
               status: 'processing'
             });
           } catch (e) {
-            console.warn(`   ⚠️ Could not mark request as processing: ${e.message}`);
+            console.error(`   ❌ Failed to mark request ${request.id} as processing: ${e.message}`);
+            console.error(`   🛑 Aborting minting for this request to prevent double-minting.`);
+            processingEditionRequests.delete(request.id);
+            continue;
           }
           
           const mintResult = await web3Service.mintEdition(


### PR DESCRIPTION
>
> ### Issue
> In `hardware-web3-service/server.js`, the service would proceed to mint an NFT even if the status update to `processing` on the public server failed. This caused the public server to keep the request as `pending`, leading to redundant mints on subsequent polls.
>
> ### Fix
> Updated `processEditionRequests` to abort the minting process if the status update fails.
>
> ```javascript
> try {
>   await claimClient.updateEditionRequest(request.id, { status: 'processing' });
> } catch (e) {
>   console.error(`❌ Status update failed for ${request.id}. Aborting mint.`);
>   processingEditionRequests.delete(request.id);
>   continue; // Skip minting
> }
>
> // Proceed to mint only if status update succeeded
> const mintResult = await web3Service.mintEdition(...);
> ```
>
> ### Result
> Each edition request is now guaranteed to be marked as `processing` before an on-chain transaction is initiated, preventing double-minting during network flickers.