### PR TITLE
chore: remove unused @lighthouse-web3/sdk from hardware-web3-service

### DIFF
--- a/hardware-web3-service/package.json
+++ b/hardware-web3-service/package.json
@@ -22,7 +22,6 @@
     "multer": "^1.4.5-lts.1",
     "form-data": "^4.0.0",
     "@filoz/synapse-sdk": "0.35.3",
-    "@lighthouse-web3/sdk": "^0.4.3",
     "viem": "^2.0.0",
     "@privy-io/server-auth": "^1.0.0"
   },


### PR DESCRIPTION
## What

`@lighthouse-web3/sdk` is listed in [hardware-web3-service/package.json](cci:7://file:///d:/gs/lensmint-camera/hardware-web3-service/package.json:0:0-0:0) 
but never imported or used anywhere in the codebase. 

The project uses `@filoz/synapse-sdk` for Filecoin uploads instead.

## Fix

Removed the unused dependency to reduce install size and avoid 
confusion about which Filecoin SDK is actually in use.
