### PR TITLE
fix: remove duplicate express.json() middleware in public server

### DIFF
--- a/lensmint-public-server/server.js
+++ b/lensmint-public-server/server.js
@@ -38,7 +38,6 @@ app.use((req, res, next) => {
   }
 });
 
-app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static('public'));
 


### PR DESCRIPTION
## What

`express.json()` was registered twice in [lensmint-public-server/server.js](cci:7://file:///d:/gs/lensmint-camera/lensmint-public-server/server.js:0:0-0:0):
- Line 13 (first registration - keep this one)
- Line 41 (duplicate - removed)

## Fix

Removed the duplicate `app.use(express.json())` on line 41. 
While Express handles this gracefully, the duplicate is unnecessary 
overhead from a previous refactor.
