### PR TITLE
chore: remove unused multer dependency from public server

### DIFF
--- a/lensmint-public-server/package.json
+++ b/lensmint-public-server/package.json
@@ -15,8 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "better-sqlite3": "^9.2.2",
-    "uuid": "^9.0.1",
-    "multer": "^1.4.5-lts.1"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
## What

`multer` is listed as a dependency in [lensmint-public-server/package.json](cci:7://file:///d:/gs/lensmint-camera/lensmint-public-server/package.json:0:0-0:0) 
but is never imported or used anywhere. The public claim server handles 
no file uploads — it only processes claim requests and serves HTML pages.

## Fix

Removed the unused `multer` dependency.
