### PR TITLE
fix: add access control to mintEdition and batchMintEditions

### DIFF
--- a/contracts/src/LensMintERC1155.sol
+++ b/contracts/src/LensMintERC1155.sol
@@ -9,6 +9,8 @@ import "./DeviceRegistry.sol";
 contract LensMintERC1155 is ERC1155, Ownable {
     using Strings for uint256;
 
+    error UnauthorizedMinter();
+
     // Reference to device registry for validation
     DeviceRegistry public deviceRegistry;
     string public baseURI;
@@ -95,6 +97,8 @@ contract LensMintERC1155 is ERC1155, Ownable {
         TokenMetadata memory original = tokenMetadata[_originalTokenId];
         require(original.deviceAddress != address(0), "Token does not exist");
         require(original.isOriginal, "Token is not an original");
+        if (msg.sender != original.deviceAddress && msg.sender != owner())
+            revert UnauthorizedMinter();
         require(
             original.maxEditions == 0 || editionCount[_originalTokenId] < original.maxEditions,
             "Max editions reached"
@@ -133,6 +137,8 @@ contract LensMintERC1155 is ERC1155, Ownable {
         require(original.deviceAddress != address(0), "Token does not exist");
         require(original.isOriginal, "Token is not an original");
         require(_quantity > 0, "Quantity must be > 0");
+        if (msg.sender != original.deviceAddress && msg.sender != owner())
+            revert UnauthorizedMinter();
 
         uint256[] memory tokenIds = new uint256[](_quantity);
 


### PR DESCRIPTION
## Problem

`mintEdition()` and `batchMintEditions()` in `LensMintERC1155.sol` have no access control. Any address can:

1. Mint unlimited editions of any original token
2. Bypass the `maxEditions` limit
3. Create editions of tokens from devices they dont own

This breaks the core provenance model. LensMint's value prop is that every edition is cryptographically tied to the device that captured the original photo. Without this check that guarantee means nothing at the contract level.

## Fix

Added `UnauthorizedMinter` custom error and restricted both functions to the device address stored in the original token's `TokenInfo`, or the contract owner.

```solidity
error UnauthorizedMinter();

if (msg.sender != original.deviceAddress && msg.sender != owner())
    revert UnauthorizedMinter();
```

## Related

Complements PR #4 (ECDSA signature verification). Together these close the two main authorization gaps in the minting flow.