### PR TITLE
fix: Secure unauthenticated proof status update

### DIFF
--- a/hardware-web3-service/claimClient.js
+++ b/hardware-web3-service/claimClient.js
@@ -4,12 +4,19 @@ class ClaimClient {
   constructor() {
     this.baseURL = process.env.CLAIM_SERVER_URL || 'https://lensmint.onrender.com';
     const timeout = parseInt(process.env.CLAIM_CLIENT_TIMEOUT || '30000', 10);
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (process.env.API_SECRET) {
+      headers['Authorization'] = `Bearer ${process.env.API_SECRET}`;
+    }
+
     this.client = axios.create({
       baseURL: this.baseURL,
       timeout: timeout,
-      headers: {
-        'Content-Type': 'application/json'
-      }
+      headers: headers
     });
   }
 
@@ -168,7 +175,7 @@ class ClaimClient {
         verification_status,
         proof_tx_hash: proof_tx_hash ? `${proof_tx_hash.substring(0, 10)}...` : null
       });
-      
+
       const response = await this.client.post('/update-proof-status', {
         claim_id,
         token_id,

--- a/lensmint-public-server/server.js
+++ b/lensmint-public-server/server.js
@@ -47,7 +47,7 @@ let servicesInitialized = false;
 async function initializeServices() {
   try {
     console.log('🔄 Initializing claim server services...');
-    
+
     dbService.initialize();
     console.log('✅ Database initialized');
 
@@ -61,11 +61,33 @@ async function initializeServices() {
 
 initializeServices();
 
-app.post('/create-claim', (req, res) => {
+// Middleware to protect internal API routes
+const requireAuth = (req, res, next) => {
+  const apiSecret = process.env.API_SECRET;
+
+  if (!apiSecret) {
+    console.error('⚠️ API_SECRET environment variable is missing.');
+    return res.status(500).json({ success: false, error: 'Server misconfiguration: missing API_SECRET' });
+  }
+
+  const authHeader = req.headers['authorization'] || req.headers['Authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ success: false, error: 'Authentication required' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  if (token !== apiSecret) {
+    return res.status(401).json({ success: false, error: 'Invalid authentication token' });
+  }
+
+  next();
+};
+
+app.post('/create-claim', requireAuth, (req, res) => {
   try {
-    const { 
-      claim_id, 
-      cid, 
+    const {
+      claim_id,
+      cid,
       metadata_cid,
       device_id,
       camera_id,
@@ -82,9 +104,9 @@ app.post('/create-claim', (req, res) => {
     }
 
     const claim = dbService.createClaim(
-      claim_id, 
-      null, 
-      cid, 
+      claim_id,
+      null,
+      cid,
       metadata_cid || null,
       device_id || null,
       camera_id || null,
@@ -204,13 +226,13 @@ app.get('/api/metadata/:claim_id', (req, res) => {
   }
 });
 
-app.post('/update-proof-status', (req, res) => {
+app.post('/update-proof-status', requireAuth, (req, res) => {
   try {
-    const { 
-      claim_id, 
-      token_id, 
-      verification_status, 
-      proof_tx_hash 
+    const {
+      claim_id,
+      token_id,
+      verification_status,
+      proof_tx_hash
     } = req.body;
 
     if (!claim_id) {
@@ -243,9 +265,9 @@ app.post('/update-proof-status', (req, res) => {
 app.get('/verify/:claim_id', async (req, res) => {
   try {
     const { claim_id } = req.params;
-    
+
     const claim = dbService.getClaim(claim_id);
-    
+
     if (!claim) {
       return res.status(404).send(`
         <!DOCTYPE html>
@@ -294,7 +316,7 @@ app.get('/verify/:claim_id', async (req, res) => {
     };
 
     let proofData = dbService.getProof(claim_id);
-    
+
     if (proofData) {
       console.log(`[VERIFY] Found proof in local DB: status=${proofData.verification_status}, tx=${proofData.proof_tx_hash || 'none'}`);
     } else {
@@ -759,10 +781,10 @@ app.get('/claim/:claim_id', (req, res) => {
         ` : ''}
         
         <div id="status" class="status ${claim.status}">
-          ${claim.status === 'open' ? `Status: Open - Ready for editions! Original Token ID: ${claim.token_id || 'N/A'}` : 
-            claim.status === 'claimed' ? `Status: Claimed - Address: ${claim.recipient_address}` :
-            claim.status === 'completed' ? 'Status: Completed - NFT Minted! 🎉' :
-            'Status: Pending - Waiting for original NFT to be minted...'}
+          ${claim.status === 'open' ? `Status: Open - Ready for editions! Original Token ID: ${claim.token_id || 'N/A'}` :
+      claim.status === 'claimed' ? `Status: Claimed - Address: ${claim.recipient_address}` :
+        claim.status === 'completed' ? 'Status: Completed - NFT Minted! 🎉' :
+          'Status: Pending - Waiting for original NFT to be minted...'}
         </div>
 
         <form id="claimForm" ${claim.status === 'open' ? '' : 'style="display:none;"'}>
@@ -970,7 +992,7 @@ app.post('/claim/:claim_id/submit', (req, res) => {
   }
 });
 
-app.post('/update-claim-status', (req, res) => {
+app.post('/update-claim-status', requireAuth, (req, res) => {
   try {
     const { claim_id, status, token_id, tx_hash } = req.body;
 
@@ -1007,7 +1029,7 @@ app.post('/update-claim-status', (req, res) => {
   }
 });
 
-app.post('/create-edition-request', (req, res) => {
+app.post('/create-edition-request', requireAuth, (req, res) => {
   try {
     const { claim_id, wallet_address } = req.body;
 
@@ -1058,7 +1080,7 @@ app.post('/create-edition-request', (req, res) => {
   }
 });
 
-app.get('/get-pending-edition-requests', (req, res) => {
+app.get('/get-pending-edition-requests', requireAuth, (req, res) => {
   try {
     const limit = parseInt(req.query.limit) || 50;
     const requests = dbService.getPendingEditionRequests(limit);
@@ -1077,7 +1099,7 @@ app.get('/get-pending-edition-requests', (req, res) => {
   }
 });
 
-app.post('/update-edition-request', (req, res) => {
+app.post('/update-edition-request', requireAuth, (req, res) => {
   try {
     const { request_id, status, tx_hash, token_id, error_message } = req.body;
 
@@ -1116,7 +1138,7 @@ app.post('/update-edition-request', (req, res) => {
   }
 });
 
-app.post('/complete-claim', (req, res) => {
+app.post('/complete-claim', requireAuth, (req, res) => {
   try {
     const { claim_id, tx_hash, token_id } = req.body;
 
@@ -1161,7 +1183,7 @@ app.get('/health', (req, res) => {
 
 app.listen(PORT, async () => {
   await initializeServices();
-  
+
   console.log('═══════════════════════════════════════');
   console.log('🎫 LensMint Claim Server');
   console.log('═══════════════════════════════════════');


### PR DESCRIPTION
## Description
This PR addresses a critical security vulnerability where the `POST /update-proof-status` endpoint (and other sensitive state-mutating endpoints) in the `lensmint-public-server` lacked any form of authentication.

Previously, a malicious actor could bypass the Zero-Knowledge proof generation process by calling the endpoint and marking an unverified image's claim ID as "verified" with a fake transaction hash. 

### Changes Made:
1. **[lensmint-public-server/server.js](cci:7://file:///home/arpit/Desktop/Gsoc/lensmint-camera/lensmint-public-server/server.js:0:0-0:0)**: Added a [requireAuth](cci:1://file:///home/arpit/Desktop/Gsoc/lensmint-camera/lensmint-public-server/server.js:63:0-83:2) middleware based on a Shared Secret Webhook method. This middleware checks for a valid `Authorization: Bearer <API_SECRET>` header and rejects unauthorized requests with a `401 Unauthorized` error.
2. **[hardware-web3-service/claimClient.js](cci:7://file:///home/arpit/Desktop/Gsoc/lensmint-camera/hardware-web3-service/claimClient.js:0:0-0:0)**: Updated the Axios client constructor to automatically attach the `Authorization` header containing the `API_SECRET` to all outgoing requests. 

## Impact & Security Gains
- Completely prevents malicious manipulation of the ZK proof verification status.
- State-mutating routes like `/create-claim`, `/update-proof-status`, `/update-claim-status`, and others are now fully protected.
- ***Note:*** This change requires setting the `API_SECRET` environment variable in both the server's `.env` and the client's `.env` files.

## Proof of Fix

When a malicious actor attempts to send a forged request *without* the `Authorization` header, the server now correctly blocks the payload:

**Malicious Request:**
```bash
curl -X POST http://localhost:5001/update-proof-status \
  -H "Content-Type: application/json" \
  -d '{
    "claim_id": "test_claim_123",
    "verification_status": "verified",
    "proof_tx_hash": "0xFakeTransactionHash12345"
  }'
```

## Server Response (Successfully Blocked):


<img width="712" height="192" alt="image" src="https://github.com/user-attachments/assets/61147f25-92da-42f3-9909-7edfc370020a" />

When an authorized client (like our hardware-web3-service) sends a request with the correct secret, it processes correctly.


fixes #11 
