### PR TITLE
fix: Add access control to DeviceRegistry registration

### DIFF
--- a/contracts/src/DeviceRegistry.sol
+++ b/contracts/src/DeviceRegistry.sol
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 /**
  * @title DeviceRegistry
  * @dev Manages registration and activation of camera devices
  */
-contract DeviceRegistry {
+contract DeviceRegistry is Ownable {
+    constructor() Ownable(msg.sender) {}
+
     struct DeviceInfo {
         address deviceAddress;
         string publicKey;
@@ -21,24 +25,21 @@ contract DeviceRegistry {
     mapping(address => DeviceInfo) public devices;
     mapping(string => address) public deviceIdToAddress;
     address[] public registeredDevices;
-    
+
     event DeviceRegistered(
         address indexed deviceAddress,
         string deviceId,
         string publicKey,
         address indexed registeredBy
     );
-    
+
     event DeviceUpdated(
         address indexed deviceAddress,
         string deviceId,
         bool isActive
     );
-    
-    event DeviceDeactivated(
-        address indexed deviceAddress,
-        string deviceId
-    );
+
+    event DeviceDeactivated(address indexed deviceAddress, string deviceId);
     function registerDevice(
         address _deviceAddress,
         string memory _publicKey,
@@ -46,13 +47,19 @@ contract DeviceRegistry {
         string memory _cameraId,
         string memory _model,
         string memory _firmwareVersion
-    ) external {
+    ) external onlyOwner {
         require(_deviceAddress != address(0), "Invalid device address");
         require(bytes(_publicKey).length > 0, "Public key required");
         require(bytes(_deviceId).length > 0, "Device ID required");
         require(bytes(_cameraId).length > 0, "Camera ID required");
-        require(devices[_deviceAddress].deviceAddress == address(0), "Device already registered");
-        require(deviceIdToAddress[_deviceId] == address(0), "Device ID already in use");
+        require(
+            devices[_deviceAddress].deviceAddress == address(0),
+            "Device already registered"
+        );
+        require(
+            deviceIdToAddress[_deviceId] == address(0),
+            "Device ID already in use"
+        );
 
         DeviceInfo memory newDevice = DeviceInfo({
             deviceAddress: _deviceAddress,
@@ -70,7 +77,12 @@ contract DeviceRegistry {
         deviceIdToAddress[_deviceId] = _deviceAddress;
         registeredDevices.push(_deviceAddress);
 
-        emit DeviceRegistered(_deviceAddress, _deviceId, _publicKey, msg.sender);
+        emit DeviceRegistered(
+            _deviceAddress,
+            _deviceId,
+            _publicKey,
+            msg.sender
+        );
     }
 
     function updateDevice(
@@ -104,15 +116,21 @@ contract DeviceRegistry {
         emit DeviceDeactivated(_deviceAddress, device.deviceId);
     }
 
-    function getDevice(address _deviceAddress) external view returns (DeviceInfo memory) {
+    function getDevice(
+        address _deviceAddress
+    ) external view returns (DeviceInfo memory) {
         return devices[_deviceAddress];
     }
 
-    function getDeviceByDeviceId(string memory _deviceId) external view returns (address) {
+    function getDeviceByDeviceId(
+        string memory _deviceId
+    ) external view returns (address) {
         return deviceIdToAddress[_deviceId];
     }
 
-    function isDeviceActive(address _deviceAddress) external view returns (bool) {
+    function isDeviceActive(
+        address _deviceAddress
+    ) external view returns (bool) {
         DeviceInfo memory device = devices[_deviceAddress];
         return device.deviceAddress != address(0) && device.isActive;
     }
@@ -125,4 +143,3 @@ contract DeviceRegistry {
         return registeredDevices;
     }
 }
-


### PR DESCRIPTION
##  Fix: Missing Access Control on Device Registration

### Description
This Pull Request addresses a **critical security vulnerability** in `DeviceRegistry.sol` where the `registerDevice` function was **publicly accessible without any access control**.

Previously, **any Ethereum address** could register itself as a valid device. This bypassed the hardware authenticity requirement and allowed attackers to mint **forged NFTs** by registering malicious device addresses.

---

##  Changes Made

### 1. Inherited `Ownable`
Modified `DeviceRegistry` to inherit from **OpenZeppelin's `Ownable` contract** to introduce a standard access-control mechanism.

### 2. Initialized Owner
Added a constructor to properly initialize the `Ownable` state with `msg.sender` as the contract owner.

### 3. Restricted Device Registration
Applied the `onlyOwner` modifier to the `registerDevice` function to ensure that only the contract owner can register new devices.

---

##  Impact & Security Gains

- Only the **contract owner (deployer)** can authorize and register new devices.
- Prevents attackers from **injecting malicious device addresses** into the registry.
- Restores the **trust model of the system** by ensuring that only legitimate hardware devices can be registered.

---

fix #13 