### PR TITLE
fix: Implement pagination for device retrieval to prevent DoS

### DIFF
--- a/contracts/src/DeviceRegistry.sol
+++ b/contracts/src/DeviceRegistry.sol
@@ -21,24 +21,21 @@ contract DeviceRegistry {
     mapping(address => DeviceInfo) public devices;
     mapping(string => address) public deviceIdToAddress;
     address[] public registeredDevices;
-    
+
     event DeviceRegistered(
         address indexed deviceAddress,
         string deviceId,
         string publicKey,
         address indexed registeredBy
     );
-    
+
     event DeviceUpdated(
         address indexed deviceAddress,
         string deviceId,
         bool isActive
     );
-    
-    event DeviceDeactivated(
-        address indexed deviceAddress,
-        string deviceId
-    );
+
+    event DeviceDeactivated(address indexed deviceAddress, string deviceId);
     function registerDevice(
         address _deviceAddress,
         string memory _publicKey,
@@ -51,8 +48,14 @@ contract DeviceRegistry {
         require(bytes(_publicKey).length > 0, "Public key required");
         require(bytes(_deviceId).length > 0, "Device ID required");
         require(bytes(_cameraId).length > 0, "Camera ID required");
-        require(devices[_deviceAddress].deviceAddress == address(0), "Device already registered");
-        require(deviceIdToAddress[_deviceId] == address(0), "Device ID already in use");
+        require(
+            devices[_deviceAddress].deviceAddress == address(0),
+            "Device already registered"
+        );
+        require(
+            deviceIdToAddress[_deviceId] == address(0),
+            "Device ID already in use"
+        );
 
         DeviceInfo memory newDevice = DeviceInfo({
             deviceAddress: _deviceAddress,
@@ -70,7 +73,12 @@ contract DeviceRegistry {
         deviceIdToAddress[_deviceId] = _deviceAddress;
         registeredDevices.push(_deviceAddress);
 
-        emit DeviceRegistered(_deviceAddress, _deviceId, _publicKey, msg.sender);
+        emit DeviceRegistered(
+            _deviceAddress,
+            _deviceId,
+            _publicKey,
+            msg.sender
+        );
     }
 
     function updateDevice(
@@ -104,15 +112,21 @@ contract DeviceRegistry {
         emit DeviceDeactivated(_deviceAddress, device.deviceId);
     }
 
-    function getDevice(address _deviceAddress) external view returns (DeviceInfo memory) {
+    function getDevice(
+        address _deviceAddress
+    ) external view returns (DeviceInfo memory) {
         return devices[_deviceAddress];
     }
 
-    function getDeviceByDeviceId(string memory _deviceId) external view returns (address) {
+    function getDeviceByDeviceId(
+        string memory _deviceId
+    ) external view returns (address) {
         return deviceIdToAddress[_deviceId];
     }
 
-    function isDeviceActive(address _deviceAddress) external view returns (bool) {
+    function isDeviceActive(
+        address _deviceAddress
+    ) external view returns (bool) {
         DeviceInfo memory device = devices[_deviceAddress];
         return device.deviceAddress != address(0) && device.isActive;
     }
@@ -124,5 +138,31 @@ contract DeviceRegistry {
     function getAllDevices() external view returns (address[] memory) {
         return registeredDevices;
     }
-}
 
+    /**
+     * @dev Returns a paginated list of registered devices to avoid gas limit issues.
+     * @param cursor The starting index (0-indexed).
+     * @param count The number of device addresses to return.
+     */
+    function getDevicesPaginated(
+        uint256 cursor,
+        uint256 count
+    ) external view returns (address[] memory) {
+        uint256 total = registeredDevices.length;
+        if (cursor >= total || count == 0) {
+            return new address[](0);
+        }
+
+        uint256 length = count;
+        if (cursor + count > total) {
+            length = total - cursor;
+        }
+
+        address[] memory devicesList = new address[](length);
+        for (uint256 i = 0; i < length; i++) {
+            devicesList[i] = registeredDevices[cursor + i];
+        }
+
+        return devicesList;
+    }
+}


### PR DESCRIPTION

### Description
This Pull Request addresses a **Denial of Service (DoS)** vulnerability in `DeviceRegistry.sol` where the `getAllDevices` function returned an **unbounded array**.

As the number of registered devices grows, returning the entire array could eventually **exceed the Ethereum block gas limit**, causing the function to revert. This would make it impossible for applications to retrieve device information.

---

##  Changes Made

### 1. Implemented `getDevicesPaginated`
Added a new `view` function that allows callers to retrieve a **subset of the `registeredDevices` array** using `cursor` and `count` parameters.

### 2. Safe Indexing
Included validation checks to ensure:
- The `cursor` remains **within valid bounds**
- The returned array length is **properly capped by the total number of registered devices**

---

##  Impact & Security Gains

- Prevents **gas limit exhaustion** when the dataset grows large.
- Ensures the system remains **scalable** as the number of registered cameras increases.
- Provides a **reliable and efficient method** for frontends and indexers to fetch device lists.

---
fixes #14 