### PR TITLE
feat: extend /health endpoint with dependency status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@
 ## 📸 Gallery
 
 ### 🖼️ Logo
+
 <div align="center">
   <img src="assets/lensmintlogo.png" alt="LensMint Logo" width="300"/>
 </div>
 
 ### 🔧 Hardware Components
+
 <div align="center">
   <table>
     <tr>
@@ -42,6 +44,7 @@
 </div>
 
 ### 💻 Backend Screenshots
+
 <div align="center">
   <table>
     <tr>
@@ -67,6 +70,7 @@
 </div>
 
 ### 📷 Physical Camera Final Images
+
 <div align="center">
   <table>
     <tr>
@@ -104,6 +108,7 @@
 ### Core Innovation: Proof of Authenticity + Creator Monetization
 
 Every photo captured solves real problems:
+
 - **🔍 Prove It's Real**: Cryptographic proof images aren't AI-generated or manipulated
 - **💰 Tag for Payment**: Tag people in images to automatically distribute royalties
 - **🎫 Proof of Attendance**: Verify who was at events, easy minting for attendees
@@ -116,6 +121,7 @@ Every photo captured solves real problems:
 **LensMint** solves these real problems with blockchain technology:
 
 ### 🔐 Proof of Authenticity
+
 - **Zero-Knowledge Proofs (vlayer)**: Generate cryptographic proofs that images are real, not AI-generated or manipulated
 - **Hardware-Based Identity**: Each camera has unique cryptographic identity - proves which device captured the image
 - **RISC Zero Verification**: On-chain verification of authenticity proofs using RISC Zero verifier contracts
@@ -123,6 +129,7 @@ Every photo captured solves real problems:
 - **Device Metadata**: Cryptographic proof of camera model, location, and capture conditions
 
 ### 💰 Creator Monetization & Tagging
+
 - **Automatic NFT Minting**: Every photo becomes an NFT - creators own their content
 - **Tag-Based Payments**: Tag people in images to automatically distribute royalties
 - **Direct Payments**: Receive payments directly via smart contracts, no middlemen
@@ -130,6 +137,7 @@ Every photo captured solves real problems:
 - **Revenue Sharing**: Smart contracts automatically split payments between tagged creators
 
 ### 🎫 Proof of Attendance & Memory
+
 - **Proof of Attendance**: Verify who was present at events using blockchain verification
 - **Proof of Memory**: Cryptographic proof that important moments were captured
 - **Easy Minting for Others**: Mint NFTs for event attendees or people in photos with QR codes
@@ -137,6 +145,7 @@ Every photo captured solves real problems:
 - **Memory Preservation**: Permanent blockchain records of important moments
 
 ### 💾 Permanent Storage & Ownership
+
 - **Filecoin Storage**: Images stored permanently on decentralized network
 - **True Ownership**: NFTs prove you own the original content
 - **No Platform Lock-in**: Your content lives on blockchain, not platforms
@@ -147,6 +156,7 @@ Every photo captured solves real problems:
 ## ✨ Features
 
 ### 📸 Camera Features
+
 - **Live Preview**: Real-time camera feed with 30 FPS preview
 - **High-Quality Capture**: 1920x1080 photo resolution with rotation support
 - **Video Recording**: H.264 video recording with configurable duration
@@ -155,12 +165,14 @@ Every photo captured solves real problems:
 - **Touch-Optimized UI**: Designed for 3.5" touchscreen displays
 
 ### 🔐 Security & Identity
+
 - **Hardware Identity**: Unique cryptographic key derived from device hardware
 - **Image Signing**: Every photo is cryptographically signed with device key
 - **Device Registration**: On-chain device registry ensures only authorized cameras can mint
 - **Camera ID**: Unique camera hardware identifier for provenance tracking
 
 ### 🌐 Web3 & Blockchain Features
+
 - **Zero-Knowledge Proofs**: Generate ZK proofs using vlayer from external metadata APIs
 - **RISC Zero Verification**: On-chain ZK proof verification via RISC Zero verifier contracts
 - **Automatic NFT Minting**: ERC-1155 tokens auto-minted with device-signed metadata
@@ -171,6 +183,7 @@ Every photo captured solves real problems:
 - **On-Chain Provenance**: Complete immutable history tracked on blockchain
 
 ### 🎨 User Experience
+
 - **Battery Monitoring**: Real-time battery level display
 - **Status Indicators**: Visual feedback for upload, minting, and claim status
 - **Offline Support**: Queue system for offline captures
@@ -746,25 +759,41 @@ pip install -r requirements.txt
 pip install kivy[base] pillow numpy opencv-python requests qrcode[pil]
 ```
 
-### Step 4: Install Hardware Web3 Service Dependencies
+### Step 4: Initialize Hardware Identity
+
+```bash
+cd hardware-camera-app
+python3 hardware_identity.py
+```
+
+**Note:**
+
+Make sure all required environment variables are set before starting the services.
+
+Missing variables (like WEB_PROVER_API_CLIENT_ID or RPC_URL) can cause the backend to fail during startup.
+
+You can refer to the `.env.example` files for guidance.
+
+### Step 5: Install Hardware Web3 Service Dependencies
 
 ```bash
 cd ../hardware-web3-service
 npm install
 ```
 
-### Step 5: Install Public Server Dependencies
+### Step 6: Install Public Server Dependencies
 
 ```bash
 cd ../lensmint-public-server
 npm install
 ```
 
-### Step 6: Configure Environment Variables
+### Step 7: Configure Environment Variables
 
 Create `.env` files in `hardware-web3-service` and `lensmint-public-server` directories with your configuration settings.
 
 **For Privy Integration (Owner Portal):**
+
 - Add to `hardware-web3-service/.env`:
   ```
   PRIVY_APP_ID=your-privy-app-id
@@ -775,13 +804,6 @@ Create `.env` files in `hardware-web3-service` and `lensmint-public-server` dire
   VITE_PRIVY_APP_ID=your-privy-app-id
   VITE_BACKEND_URL=http://localhost:5000
   ```
-
-### Step 7: Initialize Hardware Identity
-
-```bash
-cd hardware-camera-app
-python3 hardware_identity.py
-```
 
 ### Step 8: Start Services
 
@@ -817,6 +839,7 @@ npm run dev
 ```
 
 The owner portal will be available at `http://localhost:3000`. This allows the owner to:
+
 - Login with Privy (wallet, email, or SMS)
 - Setup session signers for backend transaction signing
 - Mint NFTs with automatic gas sponsorship
@@ -851,6 +874,7 @@ WantedBy=multi-user.target
 ```
 
 Enable and start:
+
 ```bash
 sudo systemctl enable lensmint.service
 sudo systemctl start lensmint.service
@@ -862,25 +886,25 @@ sudo systemctl start lensmint.service
 
 ### Minimum Requirements
 
-| Component | Specification |
-|-----------|--------------|
-| **Raspberry Pi** | Raspberry Pi 4 Model B (2GB+ RAM) |
-| **Camera** | Raspberry Pi Camera Module v1/v2/v3 or USB camera |
-| **Display** | 3.5" Touchscreen Display (320x240 or higher) |
-| **Storage** | MicroSD Card (16GB+, Class 10) |
-| **Power** | 5V 3A USB-C Power Supply |
-| **Network** | WiFi or Ethernet connection |
+| Component        | Specification                                     |
+| ---------------- | ------------------------------------------------- |
+| **Raspberry Pi** | Raspberry Pi 4 Model B (2GB+ RAM)                 |
+| **Camera**       | Raspberry Pi Camera Module v1/v2/v3 or USB camera |
+| **Display**      | 3.5" Touchscreen Display (320x240 or higher)      |
+| **Storage**      | MicroSD Card (16GB+, Class 10)                    |
+| **Power**        | 5V 3A USB-C Power Supply                          |
+| **Network**      | WiFi or Ethernet connection                       |
 
 ### Recommended Setup
 
-| Component | Recommendation |
-|-----------|----------------|
-| **Raspberry Pi** | Raspberry Pi 4 Model B (4GB RAM) |
-| **Camera** | Raspberry Pi Camera Module v3 |
-| **Display** | Waveshare 3.5" HDMI LCD Touchscreen |
-| **Storage** | MicroSD Card (32GB+, Class 10, A1) |
-| **Power** | UPS HAT for battery backup |
-| **Cooling** | Heat sinks and fan for extended use |
+| Component        | Recommendation                      |
+| ---------------- | ----------------------------------- |
+| **Raspberry Pi** | Raspberry Pi 4 Model B (4GB RAM)    |
+| **Camera**       | Raspberry Pi Camera Module v3       |
+| **Display**      | Waveshare 3.5" HDMI LCD Touchscreen |
+| **Storage**      | MicroSD Card (32GB+, Class 10, A1)  |
+| **Power**        | UPS HAT for battery backup          |
+| **Cooling**      | Heat sinks and fan for extended use |
 
 ### Optional Components
 
@@ -961,8 +985,10 @@ sudo systemctl start lensmint.service
 ## 🎯 Real-World Use Cases
 
 ### 1. **Wildlife Photography & Media**
+
 **Problem**: Need to prove wildlife photos are authentic, not staged or AI-generated
-**Solution**: 
+**Solution**:
+
 - Cryptographic proof of capture device and timestamp
 - ZK proofs verify authenticity without exposing location data
 - NFTs enable direct monetization from media outlets
@@ -971,8 +997,10 @@ sudo systemctl start lensmint.service
 **Example**: National Geographic photographer captures rare wildlife - media outlets can verify authenticity before purchasing, photographer gets paid directly via NFT sales
 
 ### 2. **Content Creator Monetization**
+
 **Problem**: Creators lose 30-50% to platforms, can't track usage, hard to get paid
 **Solution**:
+
 - Automatic NFT minting gives creators ownership
 - Tag people in images for automatic revenue sharing
 - Smart contracts track usage and distribute payments
@@ -981,8 +1009,10 @@ sudo systemctl start lensmint.service
 **Example**: Photographer tags models in fashion shoot - when image is used commercially, smart contract automatically splits payment between photographer and models
 
 ### 3. **News & Journalism**
+
 **Problem**: Can't prove photos are real vs. AI-generated deepfakes
 **Solution**:
+
 - Hardware-based proof of capture device
 - ZK proofs verify authenticity without exposing sources
 - Blockchain timestamps prove when events occurred
@@ -991,8 +1021,10 @@ sudo systemctl start lensmint.service
 **Example**: Journalist captures breaking news - blockchain proof verifies it's real, not AI-generated, protecting journalism integrity
 
 ### 4. **Proof of Attendance at Events**
+
 **Problem**: Can't prove who was actually at events, hard to mint NFTs for attendees
 **Solution**:
+
 - Proof of attendance via blockchain verification
 - Easy minting for event attendees
 - Verified presence records
@@ -1001,8 +1033,10 @@ sudo systemctl start lensmint.service
 **Example**: Conference organizer captures group photo - attendees scan QR code to claim their proof of attendance NFT, permanently recorded on blockchain
 
 ### 5. **Memory Preservation & Minting**
+
 **Problem**: Important moments aren't permanently recorded, hard to mint NFTs for others
 **Solution**:
+
 - Proof of memory for captured moments
 - Easy minting for people in photos
 - Permanent blockchain records
@@ -1011,8 +1045,10 @@ sudo systemctl start lensmint.service
 **Example**: Wedding photographer captures moments - guests can easily claim their memory NFTs, creating permanent proof of attendance and shared memories
 
 ### 6. **Scientific Documentation**
+
 **Problem**: Need tamper-proof proof of research documentation
 **Solution**:
+
 - Cryptographic proof of capture device and conditions
 - Immutable timestamps prove when research occurred
 - Permanent storage ensures data can't be lost
@@ -1020,12 +1056,12 @@ sudo systemctl start lensmint.service
 
 **Example**: Field researcher documents rare species - blockchain proof verifies authenticity for scientific publication
 
-
 ---
 
 ## 🔧 Technical Stack
 
 ### Frontend (Hardware Camera App)
+
 - **Python 3.9+**: Core language
 - **Kivy 2.1+**: UI framework
 - **Picamera2**: Camera interface
@@ -1033,6 +1069,7 @@ sudo systemctl start lensmint.service
 - **Requests**: HTTP client
 
 ### Hardware Web3 Service
+
 - **Node.js 18+**: Runtime
 - **Express.js**: Web framework
 - **Ethers.js**: Blockchain interaction
@@ -1040,12 +1077,14 @@ sudo systemctl start lensmint.service
 - **Multer**: File upload handling
 
 ### Blockchain
+
 - **Ethereum Sepolia**: Testnet
 - **Solidity**: Smart contracts
 - **Foundry**: Development framework
 - **OpenZeppelin**: Contract libraries
 
 ### Storage
+
 - **Filecoin**: Decentralized storage
 - **Synapse SDK**: Filecoin integration
 - **IPFS**: Content addressing
@@ -1055,17 +1094,20 @@ sudo systemctl start lensmint.service
 ## 📊 Smart Contracts
 
 ### DeviceRegistry.sol
+
 - Registers authorized camera devices
 - Stores device metadata (address, camera ID, model)
 - Manages device activation status
 
 ### LensMintERC1155.sol
+
 - ERC-1155 NFT contract for multi-token standard
 - Device-only minting for originals
 - Public minting for editions
 - Transfer functionality
 
 ### LensMintVerifier.sol
+
 - **Zero-Knowledge Proof Verification**: RISC Zero verifier for ZK proof validation
 - **Device Authenticity**: Verifies device identity from ZK proof data
 - **Image Hash Verification**: Validates image integrity from external metadata
@@ -1093,11 +1135,10 @@ sudo systemctl start lensmint.service
 
 ---
 
-
-
 ## 🙏 Acknowledgments
 
 Built with:
+
 - [vlayer](https://vlayer.io/) - Zero-knowledge proof generation for authenticity verification
 - [Privy](https://privy.io/) - Wallet infrastructure and authentication
 - [Kivy](https://kivy.org/) - Python UI framework
@@ -1107,7 +1148,6 @@ Built with:
 - [Foundry](https://book.getfoundry.sh/) - Development framework
 
 ---
-
 
 <div align="center">
 

--- a/hardware-web3-service/.env.example
+++ b/hardware-web3-service/.env.example
@@ -1,11 +1,42 @@
+# Server
 PORT=5000
-CAPTURES_PATH=/home/pi/lensmint/captures
 NODE_ENV=production
 
-# Future Web3 Integration
-# WALLET_PRIVATE_KEY=your_wallet_private_key_here
-# IPFS_API_URL=https://ipfs.infura.io:5001
-# NFT_CONTRACT_ADDRESS=0x...
-# BLOCKCHAIN_RPC_URL=https://mainnet.infura.io/v3/YOUR_KEY
+# File paths
+CAPTURES_PATH=/home/pi/lensmint/captures
+DATABASE_PATH=/home/pi/lensmint/data/lensmint.db
 
-VERIFIER_CONTRACT_ADDRESS=0x0b693F079939c6C6A08AAd4cEAfbcd2cF2FdcCAc
+# Blockchain
+PRIVATE_KEY=device_wallet_private_key_here
+RPC_URL=https://sepolia.infura.io/v3/YOUR_INFURA_KEY
+SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_INFURA_KEY
+
+# Smart contracts
+DEVICE_REGISTRY_ADDRESS=DeviceRegistryContractAddress
+LENMINT_ERC1155_ADDRESS=LensMintERC1155ContractAddress
+VERIFIER_CONTRACT_ADDRESS=VerifierContractAddress
+
+# Owner wallet
+OWNER_WALLET_ADDRESS=OwnerWalletAddress
+
+# Claim server
+CLAIM_SERVER_URL=https://lensmint.onrender.com
+CLAIM_CLIENT_TIMEOUT=30000
+
+# Filecoin
+FILECOIN_NETWORK=calibration
+FILECOIN_RPC_URL=https://api.calibration.node.glif.io/rpc/v1
+DEVICE_PRIVATE_KEY=filecoin_wallet_private_key_here
+
+# ZK Proof
+WEB_PROVER_API_CLIENT_ID=vlayer_client_id_here
+WEB_PROVER_API_SECRET=vlayer_api_secret_here
+ZK_PROVER_API_URL=https://prove.vlayer.xyz
+
+# Privy
+PRIVY_APP_ID=privy_app_id_here
+PRIVY_APP_SECRET=privy_app_secret_here
+
+# Optional balances
+MIN_ETH_BALANCE=0.01
+MIN_USDFC_BALANCE=0.1

--- a/hardware-web3-service/server.js
+++ b/hardware-web3-service/server.js
@@ -248,11 +248,33 @@ function startClaimPolling() {
   console.log('✅ Claim polling started');
 }
 
-app.get('/health', (req, res) => {
-  res.json({
-    status: 'ok',
+app.get('/health', async (req, res) => {
+  const deps = {
+    database: servicesInitialized,
+    blockchain: web3Service.initialized === true,
+    filecoin: filecoinService.initialized === true,
+    claimServer: false,
+    vlayerConfigured: !!(
+      process.env.WEB_PROVER_API_CLIENT_ID &&
+      process.env.WEB_PROVER_API_SECRET
+    )
+  };
+
+  try {
+    const claimPing = await claimClient.healthCheck();
+    deps.claimServer = claimPing?.status === 'ok';
+  } catch (e) {
+    deps.claimServer = false;
+  }
+
+  const allUp = Object.values(deps).every(Boolean);
+
+  res.status(allUp ? 200 : 503).json({
+    status: allUp ? 'ok' : 'degraded',
     service: 'LensMint Backend',
-    servicesInitialized
+    servicesInitialized,
+    dependencies: deps,
+    timestamp: new Date().toISOString()
   });
 });
 

--- a/hardware-web3-service/server.js
+++ b/hardware-web3-service/server.js
@@ -25,6 +25,20 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+const requiredEnv = [
+  'WEB_PROVER_API_CLIENT_ID',
+  'WEB_PROVER_API_SECRET',
+  'RPC_URL'
+];
+
+const missing = requiredEnv.filter((key) => !process.env[key]);
+
+if (missing.length > 0) {
+  console.warn('Missing environment variables:');
+  missing.forEach((key) => console.warn(`- ${key}`));
+  console.warn('Please check your .env configuration.\n');
+}
+
 // Enable CORS for all routes
 app.use(cors());
 

--- a/lensmint-public-server/.env.example
+++ b/lensmint-public-server/.env.example
@@ -1,0 +1,16 @@
+# Server
+PORT=5001
+NODE_ENV=production
+
+# URLs
+CLAIM_SERVER_URL=https://lensmint.onrender.com
+FRONTEND_URL=https://lensmint.onrender.com
+
+# CORS
+CORS_ORIGIN=*
+
+# Database
+DATABASE_PATH=/home/pi/lensmint/public-server/claims.db
+
+# Auth
+API_SECRET=secretcode


### PR DESCRIPTION
Closes #26

## What this PR does

The current `/health` endpoint always returns `{ status: "ok" }`, even when key services like blockchain RPC, Filecoin, or the claim server are unavailable.

This PR extends the `/health` response to include the status of core dependencies, while keeping the existing response structure intact.


---

## Why this helps

The camera app relies on this endpoint to determine whether to operate in online mode or fall back to offline queuing.

If `/health` always reports success, the system may attempt uploads even when dependencies are unavailable, leading to silent failures.

With this change:

- Dependency issues are visible immediately  
- The health endpoint better reflects real system state  
- Easier debugging during setup and runtime  


---

## Changes made

- Added dependency-level checks for:
  - blockchain (web3 service)
  - filecoin service
  - claim server connectivity
  - vlayer configuration (env-based)
- Kept existing response fields unchanged
- Added `dependencies` field to health response  


---

## Scope

- No breaking changes  
- No modifications to existing logic  
- Only extends the `/health` response  


---

## Context

This came up while testing the project locally, where the service appeared healthy even when some dependencies were not available.