### PR TITLE
feat: add structured validation for upload API payload

### DIFF
--- a/hardware-web3-service/package.json
+++ b/hardware-web3-service/package.json
@@ -8,23 +8,29 @@
     "start": "node server.js",
     "dev": "nodemon server.js"
   },
-  "keywords": ["web3", "camera", "raspberry-pi", "lensmint"],
+  "keywords": [
+    "web3",
+    "camera",
+    "raspberry-pi",
+    "lensmint"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
+    "@filoz/synapse-sdk": "0.35.3",
+    "@lighthouse-web3/sdk": "^0.4.3",
+    "@privy-io/server-auth": "^1.0.0",
+    "axios": "^1.6.0",
+    "better-sqlite3": "^9.2.2",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "ethers": "^6.9.0",
-    "better-sqlite3": "^9.2.2",
-    "uuid": "^9.0.1",
-    "axios": "^1.6.0",
-    "multer": "^1.4.5-lts.1",
+    "express": "^4.18.2",
     "form-data": "^4.0.0",
-    "@filoz/synapse-sdk": "0.35.3",
-    "@lighthouse-web3/sdk": "^0.4.3",
+    "multer": "^1.4.5-lts.1",
+    "uuid": "^9.0.1",
     "viem": "^2.0.0",
-    "@privy-io/server-auth": "^1.0.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/hardware-web3-service/server.js
+++ b/hardware-web3-service/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs';
+import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import multer from 'multer';
 import dotenv from 'dotenv';
@@ -661,6 +662,13 @@ app.post('/api/device/update', async (req, res) => {
   }
 });
 
+const captureSchema = z.object({
+  deviceAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  imageHash: z.string().regex(/^(0x)?[a-fA-F0-9]{64}$/),
+  cameraId: z.string().max(64),
+  signature: z.string().optional()
+});
+
 app.post('/api/images/upload', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -705,6 +713,22 @@ app.post('/api/images/upload', upload.single('image'), async (req, res) => {
         error: 'Missing required fields: imageHash, signature, cameraId, deviceAddress'
       });
     }
+    
+    try {
+  req.body = captureSchema.parse({
+    imageHash,
+    signature,
+    cameraId,
+    deviceAddress
+  });
+} catch (error) {
+  fs.unlinkSync(req.file.path);
+  return res.status(400).json({
+    success: false,
+    error: 'Invalid request payload',
+    details: error.errors?.map(e => e.message) || error.message
+  });
+}
 
     const filename = `photo_${Date.now()}.jpg`;
     const filepath = path.join(CAPTURES_PATH, filename);


### PR DESCRIPTION
Closes #28 

## What this PR does

Adds structured validation for the `/api/images/upload` endpoint to ensure request payload fields follow expected formats before being processed.

Currently, fields like `deviceAddress` and `imageHash` are accepted without strict validation, which can lead to failures deeper in the stack (e.g., during blockchain interactions).


---

## Why this helps

- Prevents invalid data from reaching core logic  
- Improves clarity of error responses  
- Ensures uploaded files are cleaned up when validation fails  
- Makes debugging easier during development and runtime  


---

## Changes made

- Added schema-based validation for:
  - `deviceAddress` (Ethereum address format)
  - `imageHash` (hex format)
  - `cameraId` (length constraint)
- Kept existing required field checks unchanged
- Added validation step before file processing to ensure safe cleanup


---

## Scope

- No breaking changes  
- Focused only on improving input validation  


---
## Validation / Testing

Tested locally using form-data requests via Postman.

### Successful case
- Valid Ethereum address, image hash, and file upload
- Request processed successfully

### Failure cases
- Invalid `deviceAddress` → rejected with 400
- Invalid `imageHash` → rejected with 400
- Missing fields → rejected by existing checks

### File cleanup
Verified that failed uploads do not leave residual files in the `captures/` directory.

---

## Screenshots

### Successful request
<img width="2771" height="1463" alt="success" src="https://github.com/user-attachments/assets/f202a91b-228b-444f-a923-b6b99fc6029f" />



### Invalid input rejection


<img width="2915" height="1236" alt="failure" src="https://github.com/user-attachments/assets/b3f5bd6f-c184-4624-b398-072a419c16cc" />

## Context

 
This came up while reviewing the upload flow, where malformed inputs could cause unclear errors downstream during processing.