### PR TITLE
fix: replace deprecated createPrivyWagmiConfig and fix imports in owner-portal

### DIFF
--- a/owner-portal/package.json
+++ b/owner-portal/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@privy-io/react-auth": "^3.18.0",
+    "@privy-io/wagmi": "^4.0.3",
+    "@tanstack/react-query": "^5.95.0",
+    "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@privy-io/react-auth": "^2.0.0",
-    "@privy-io/wagmi": "^2.0.0",
-    "wagmi": "^2.0.0",
-    "viem": "^2.0.0",
-    "axios": "^1.6.0",
-    "@tanstack/react-query": "^5.0.0"
+    "viem": "^2.47.6",
+    "wagmi": "^3.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/owner-portal/src/App.jsx
+++ b/owner-portal/src/App.jsx
@@ -1,39 +1,43 @@
 import { PrivyProvider } from '@privy-io/react-auth'
-import { createPrivyWagmiConfig } from '@privy-io/wagmi'
-import { WagmiProvider } from 'wagmi'
+import { createConfig, WagmiProvider } from '@privy-io/wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { sepolia } from 'wagmi/chains'
+import { http } from 'viem'
+import { sepolia } from 'viem/chains'
 import OwnerDashboard from './components/OwnerDashboard'
 
 const PRIVY_APP_ID = import.meta.env.VITE_PRIVY_APP_ID || 'your-privy-app-id'
+
 const queryClient = new QueryClient()
-const wagmiConfig = createPrivyWagmiConfig({
+
+const wagmiConfig = createConfig({
   chains: [sepolia],
+  transports: {
+    [sepolia.id]: http(),
+  },
 })
 
 function App() {
   return (
-    <PrivyProvider
-      appId={PRIVY_APP_ID}
-      config={{
-        loginMethods: ['wallet', 'email', 'sms'],
-        appearance: {
-          theme: 'light',
-          accentColor: '#667eea',
-        },
-        embeddedWallets: {
-          createOnLogin: 'users-without-wallets',
-        },
-      }}
-    >
-      <WagmiProvider config={wagmiConfig}>
-        <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <PrivyProvider
+        appId={PRIVY_APP_ID}
+        config={{
+          loginMethods: ['wallet', 'email', 'sms'],
+          appearance: {
+            theme: 'light',
+            accentColor: '#667eea',
+          },
+          embeddedWallets: {
+            createOnLogin: 'users-without-wallets',
+          },
+        }}
+      >
+        <WagmiProvider config={wagmiConfig}>
           <OwnerDashboard />
-        </QueryClientProvider>
-      </WagmiProvider>
-    </PrivyProvider>
+        </WagmiProvider>
+      </PrivyProvider>
+    </QueryClientProvider>
   )
 }
 
 export default App
-


### PR DESCRIPTION
## Summary
Fixes #31

## Problem
owner-portal fails to start with two errors:
1. `createPrivyWagmiConfig` no longer exists in newer `@privy-io/wagmi` versions
2. `No QueryClient set` error due to wrong provider nesting order

## Changes
- Replaced `createPrivyWagmiConfig` with `createConfig` from `@privy-io/wagmi`
- Removed duplicate imports for `WagmiProvider`, `QueryClient` and `sepolia`
- Moved `QueryClientProvider` to outermost wrapper
- Updated privy package versions for compatibility

## Testing
- [x] owner-portal starts successfully with `npm run dev`
- [x] Wallet connects successfully
- [x] No console errors related to privy/wagmi