### PR TITLE
docs: add owner-portal setup guide and env example

### DIFF
--- a/owner-portal/.env.example
+++ b/owner-portal/.env.example
@@ -1,0 +1,6 @@
+# Privy Authentication
+# Get your App ID from https://console.privy.io
+VITE_PRIVY_APP_ID=your-privy-app-id-here
+
+# Backend URL
+VITE_BACKEND_URL=http://localhost:5000

--- a/owner-portal/README.md
+++ b/owner-portal/README.md
@@ -1,0 +1,38 @@
+# LensMint Owner Portal
+
+Web dashboard for LensMint camera owners to manage 
+their device, NFTs, and wallet.
+
+## Tech Stack
+- React + Vite
+- Privy (wallet authentication)
+- Wagmi + Viem (blockchain interaction)
+- TanStack Query
+
+## Prerequisites
+- Node.js v18+
+- A Privy account → https://console.privy.io
+
+## Setup
+
+### 1. Install dependencies
+\```bash
+npm install --legacy-peer-deps
+\```
+
+### 2. Configure environment
+\```bash
+cp .env.example .env
+\```
+Edit `.env` and add your Privy App ID from https://console.privy.io
+
+### 3. Start development server
+\```bash
+npm run dev
+\```
+Portal runs at http://localhost:3000
+
+## Known Issues
+- Use `--legacy-peer-deps` flag during install due to peer 
+  dependency conflicts between @privy-io packages
+- Disable Solana in Privy console if you see Solana connector warnings


### PR DESCRIPTION
## Summary
Adds setup documentation and environment template for the owner-portal.

## Changes
- Added `owner-portal/.env.example` with required environment variables
- Added `owner-portal/README.md` with complete setup instructions

## Why
New contributors had no guidance on how to set up the owner-portal locally. 
This follows up on #31 where missing setup clarity caused dependency issues.

## Testing
- [x] Followed the README steps on a fresh setup successfully
- [x] .env.example contains all required variables