### PR TITLE
feat(hardware): introduce Perceptual Hash (pHash) for compression-resilient ZK verification

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -6,7 +6,7 @@ solc_version = "0.8.24"
 optimizer = true
 optimizer_runs = 200
 via_ir = true
-evm_version = "paris"
+evm_version = "cancun"
 
 [profile.ci]
 fuzz = { runs = 100 }

--- a/hardware-camera-app/raspberry_pi_camera_app.py
+++ b/hardware-camera-app/raspberry_pi_camera_app.py
@@ -14,6 +14,15 @@ from io import BytesIO
 import logging
 from logging import Filter
 
+# --- NEW: Import for Perceptual Hashing (pHash) ---
+try:
+    from PIL import Image
+    import imagehash
+    PHASH_AVAILABLE = True
+except ImportError:
+    PHASH_AVAILABLE = False
+    print("Warning: imagehash library not available. Install with: pip3 install imagehash Pillow")
+
 try:
     from hardware_identity import get_hardware_identity
     HARDWARE_IDENTITY_AVAILABLE = True
@@ -1198,8 +1207,18 @@ class CameraApp(App):
             with open(filename, 'rb') as f:
                 image_data = f.read()
             
-            # Compute image hash
+            # Compute strict image hash (SHA256)
             image_hash = hashlib.sha256(image_data).hexdigest()
+            
+            # --- NEW: Compute Perceptual Hash (pHash) for ZK compression tolerance ---
+            phash_value = ""
+            if PHASH_AVAILABLE:
+                try:
+                    img = Image.open(BytesIO(image_data))
+                    phash_value = str(imagehash.phash(img))
+                    print(f"Generated pHash for ZK verification: {phash_value}")
+                except Exception as e:
+                    print(f"Error generating pHash: {e}")
             
             # Get device info
             device_address = signature_info['address']
@@ -1209,6 +1228,7 @@ class CameraApp(App):
             files = {'image': (os.path.basename(filename), image_data, 'image/jpeg')}
             data = {
                 'imageHash': image_hash,
+                'pHash': phash_value,  # Inject pHash into the metadata payload
                 'signature': signature_info['signature'],
                 'cameraId': camera_id,
                 'deviceAddress': device_address


### PR DESCRIPTION
## feat(hardware): add pHash to handle image compression

The current SHA256-based logic is a bit too "brittle"—even a tiny bit of compression during network transit breaks the entire ZK verification. To fix this, I’ve added **Perceptual Hashing (pHash)** support on the hardware side.

**What I did:**
- Integrated `imagehash` and `Pillow` to generate a visual fingerprint of the photo at capture time.
- Added a simple fallback (`PHASH_AVAILABLE`) so the app doesn't crash if these libraries aren't installed.
- Injected the `pHash` into the upload metadata.

**The Bigger Picture:**
This is actually the first step for my GSoC 2026 proposal. My plan is to use this pHash inside a **RISC Zero ZK circuit** (using Rust) to calculate **Hamming Distance**. This way, the system can mathematically tolerate minor compression while still blocking AI-generated fakes.

This approach is inspired by my research on image forensics in the "Yuanjing" project. Excited to see this moving forward!
<img width="1073" height="151" alt="image" src="https://github.com/user-attachments/assets/138cba27-ea55-4820-914c-af975b6c86c8" />
<img width="1919" height="1199" alt="屏幕截图 2026-03-23 003235" src="https://github.com/user-attachments/assets/86aa4b1f-6f8a-439f-8b3e-7b7d704b7b90" />
