### PR TITLE
feat: add claim expiry and cleanup for abandoned QR claims

### DIFF
--- a/lensmint-public-server/dbService.js
+++ b/lensmint-public-server/dbService.js
@@ -71,7 +71,8 @@ class ClaimDBService {
         token_id INTEGER,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         claimed_at DATETIME,
-        completed_at DATETIME
+        completed_at DATETIME,
+        expires_at INTEGER DEFAULT NULL
       )
     `);
 
@@ -80,7 +81,8 @@ class ClaimDBService {
       { name: 'camera_id', type: 'TEXT' },
       { name: 'image_hash', type: 'TEXT' },
       { name: 'signature', type: 'TEXT' },
-      { name: 'device_address', type: 'TEXT' }
+      { name: 'device_address', type: 'TEXT' },
+      { name: 'expires_at', type: 'INTEGER' }
     ];
 
     columnsToAdd.forEach(col => {
@@ -306,6 +308,31 @@ class ClaimDBService {
     const stmt = this.db.prepare('SELECT * FROM claims WHERE status = ? ORDER BY created_at DESC');
     return stmt.all(status);
   }
+
+  setClaimExpiry(claim_id, expires_at) {
+  const stmt = this.db.prepare(
+    'UPDATE claims SET expires_at = ? WHERE claim_id = ?'
+  );
+  stmt.run(expires_at, claim_id);
+}
+
+cleanupExpiredClaims() {
+  const stmt = this.db.prepare(`
+    UPDATE claims
+    SET status = 'expired'
+    WHERE expires_at IS NOT NULL
+      AND expires_at < ?
+      AND status = 'pending'
+  `);
+
+  const result = stmt.run(Date.now());
+
+  if (result.changes > 0) {
+    console.log(`[CLEANUP] Marked ${result.changes} expired claims`);
+  }
+
+  return result.changes;
+}
 
   createOrUpdateProof(claimId, tokenId, verificationStatus, proofTxHash = null) {
     const existing = this.getProof(claimId);

--- a/lensmint-public-server/server.js
+++ b/lensmint-public-server/server.js
@@ -93,6 +93,12 @@ app.post('/create-claim', (req, res) => {
       device_address || null
     );
 
+    // Set expiry for claim (default 15 min)
+const CLAIM_TTL_MINUTES = parseInt(process.env.CLAIM_TTL_MINUTES || '15');
+const expiresAt = Date.now() + CLAIM_TTL_MINUTES * 60 * 1000;
+
+dbService.setClaimExpiry(claim.claim_id, expiresAt);
+
     if (!claim) {
       return res.status(400).json({
         success: false,
@@ -1158,6 +1164,20 @@ app.post('/complete-claim', (req, res) => {
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', service: 'LensMint Claim Server' });
 });
+
+
+// Cleanup expired claims every 5 minutes
+setInterval(() => {
+  try {
+    const cleaned = dbService.cleanupExpiredClaims();
+    if (cleaned > 0) {
+      console.log(`[CLEANUP] Expired ${cleaned} stale claims`);
+    }
+  } catch (e) {
+    console.error('[CLEANUP] Error during claim cleanup:', e.message);
+  }
+}, 5 * 60 * 1000);
+
 
 app.listen(PORT, async () => {
   await initializeServices();


### PR DESCRIPTION
closes #36 
## What this PR does

This PR introduces a lifecycle for claims by adding expiry and periodic cleanup.

- Adds `expires_at` field to the claims table
- Sets a default TTL (15 minutes) when a claim is created
- Runs a background cleanup job every 5 minutes to mark stale claims as `expired`

## Problem

The camera app continuously polls claim status and does not stop if a QR code is never scanned.

In real-world scenarios (e.g., events), many users do not complete the claim flow.

As a result:
- Claims remain in `pending` state indefinitely
- The Raspberry Pi continues polling unnecessarily
- The database accumulates stale entries over time

## Solution

Each claim is now assigned an expiry time at creation.

A periodic cleanup process updates:
- `pending → expired` for stale claims

This ensures:
- Polling can naturally terminate
- System behavior remains predictable
- Database does not grow with unused entries

## Implementation details

- TTL is configurable via `CLAIM_TTL_MINUTES` (default: 15)
- Cleanup runs every 5 minutes using `setInterval`
- Only `pending` claims are affected
- Claimed or completed entries remain untouched

## Notes

SQLite is already configured with WAL mode in the project, which allows safe concurrent reads/writes during cleanup.

This PR intentionally keeps the change scoped to lifecycle management without introducing additional architectural complexity.

## Testing

- Created a claim → verified `expires_at` is set
- Simulated expiry → confirmed status updates to `expired`
- Verified no impact on normal claim + mint flow