### PR TITLE
feat: initial Rust PoC for hardware fingerprinting

### DIFF
--- a/rust-identity/Cargo.toml
+++ b/rust-identity/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lensmint-identity"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Using Keccak for EVM-standard cryptography
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+hex = "0.4"

--- a/rust-identity/src/main.rs
+++ b/rust-identity/src/main.rs
@@ -1,54 +1,68 @@
 use std::fs;
 use tiny_keccak::{Hasher, Keccak};
 
-/// Missing sudo privileges or running this on a Mac during dev shouldn't crash the app.
-fn get_hardware_entropy() -> Result<String, std::io::Error> {
-    let cpuinfo_result = fs::read_to_string("/proc/cpuinfo");
-    
-    match cpuinfo_result {
-        Ok(cpuinfo) => {
-            for line in cpuinfo.lines() {
-                if line.starts_with("Serial") {
-                    let serial = line.split(':').last().unwrap_or("0000").trim();
-                    return Ok(serial.to_string());
-                }
-            }
-            // Handled fallback if /proc/cpuinfo exists but lacks a serial
-            Ok("DEV_ENV_NO_HARDWARE_SERIAL".to_string())
-        }
-        Err(e) => {
-            // If the file doesn't exist (e.g., running on Windows/Mac during dev)
-            eprintln!("[SYS_WARN] Could not read /proc/cpuinfo: {}", e);
-            Ok("DEV_ENV_FALLBACK_ENTROPY".to_string())
+// Read a text file safely, returning empty string if it fails
+fn read_sys_string(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_default().trim().to_string()
+}
+
+fn get_cpu_serial() -> String {
+    let cpuinfo = read_sys_string("/proc/cpuinfo");
+    for line in cpuinfo.lines() {
+        if line.starts_with("Serial") {
+            return line.split(':').last().unwrap_or("0000").trim().to_string();
         }
     }
+    "DEV_ENV_NO_SERIAL".to_string()
+}
+
+fn get_mac_address() -> String {
+    let wlan = read_sys_string("/sys/class/net/wlan0/address");
+    if !wlan.is_empty() { return wlan; }
+    
+    let eth = read_sys_string("/sys/class/net/eth0/address");
+    if !eth.is_empty() { return eth; }
+    
+    "00:00:00:00:00:00".to_string()
+}
+
+// Read the binary salt safely as raw bytes
+fn get_salt() -> Vec<u8> {
+    fs::read("/boot/.device_salt").unwrap_or_else(|_| {
+        eprintln!("[SYS_WARN] Could not read binary salt, using fallback");
+        vec![0u8; 32]
+    })
 }
 
 fn main() {
-    // 1. Gathers hardware entropy gracefully
-    let serial = match get_hardware_entropy() {
-        Ok(s) => s,
-        Err(_) => "CRITICAL_FAILURE_FALLBACK".to_string(), 
-    };
+    // 1. Gather all hardware identifiers matching the Python architecture's footprint
+    let camera_id = "cam_01"; // Mocked for CLI PoC
+    let serial = get_cpu_serial();
+    let mac = get_mac_address();
+    let machine_id = read_sys_string("/etc/machine-id");
+    
+    // 2. Read the raw binary device salt
+    let salt = get_salt();
 
-    // Note: MAC address is mocked for this PoC. 
-    // In Phase 2, we can pull the real wlan0 physical address.
-    let mac = "00:00:00:00:00:00"; 
-
-    // 2. Hash using Keccak256 (EVM Standard)
+    // 3. Hash them together using Keccak256 (Intentional EVM-native upgrade)
     let mut keccak = Keccak::v256();
     let mut output = [0u8; 32];
     
+    keccak.update(camera_id.as_bytes());
+    keccak.update(b"|");
     keccak.update(serial.as_bytes());
-    keccak.update(b"-"); // Delimiter
+    keccak.update(b"|");
     keccak.update(mac.as_bytes());
+    keccak.update(b"|");
+    keccak.update(machine_id.as_bytes());
+    keccak.update(b"|");
+    keccak.update(&salt); // Passed as raw bytes
     keccak.finalize(&mut output);
 
-    let hardware_key = hex::encode(output);
+    let hardware_id_hash = hex::encode(output);
     
-    // 3. Output strict JSON to stdout so the Python subprocess can parse it seamlessly
     println!(
-        r#"{{"status": "success", "hardware_key": "0x{}", "entropy_source": "proc_cpuinfo"}}"#,
-        hardware_key
+        r#"{{"status": "success", "hardware_fingerprint_hash": "0x{}", "identifiers_used": ["camera_id", "cpu_serial", "mac", "machine_id", "binary_salt"]}}"#,
+        hardware_id_hash
     );
 }

--- a/rust-identity/src/main.rs
+++ b/rust-identity/src/main.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use tiny_keccak::{Hasher, Keccak};
+
+/// Missing sudo privileges or running this on a Mac during dev shouldn't crash the app.
+fn get_hardware_entropy() -> Result<String, std::io::Error> {
+    let cpuinfo_result = fs::read_to_string("/proc/cpuinfo");
+    
+    match cpuinfo_result {
+        Ok(cpuinfo) => {
+            for line in cpuinfo.lines() {
+                if line.starts_with("Serial") {
+                    let serial = line.split(':').last().unwrap_or("0000").trim();
+                    return Ok(serial.to_string());
+                }
+            }
+            // Handled fallback if /proc/cpuinfo exists but lacks a serial
+            Ok("DEV_ENV_NO_HARDWARE_SERIAL".to_string())
+        }
+        Err(e) => {
+            // If the file doesn't exist (e.g., running on Windows/Mac during dev)
+            eprintln!("[SYS_WARN] Could not read /proc/cpuinfo: {}", e);
+            Ok("DEV_ENV_FALLBACK_ENTROPY".to_string())
+        }
+    }
+}
+
+fn main() {
+    // 1. Gathers hardware entropy gracefully
+    let serial = match get_hardware_entropy() {
+        Ok(s) => s,
+        Err(_) => "CRITICAL_FAILURE_FALLBACK".to_string(), 
+    };
+
+    // Note: MAC address is mocked for this PoC. 
+    // In Phase 2, we can pull the real wlan0 physical address.
+    let mac = "00:00:00:00:00:00"; 
+
+    // 2. Hash using Keccak256 (EVM Standard)
+    let mut keccak = Keccak::v256();
+    let mut output = [0u8; 32];
+    
+    keccak.update(serial.as_bytes());
+    keccak.update(b"-"); // Delimiter
+    keccak.update(mac.as_bytes());
+    keccak.finalize(&mut output);
+
+    let hardware_key = hex::encode(output);
+    
+    // 3. Output strict JSON to stdout so the Python subprocess can parse it seamlessly
+    println!(
+        r#"{{"status": "success", "hardware_key": "0x{}", "entropy_source": "proc_cpuinfo"}}"#,
+        hardware_key
+    );
+}


### PR DESCRIPTION

Hey Mohit,

While going through the GSoC roadmap, I noticed the long-term goal of moving the camera OS to Rust. I wanted to explore that direction early, so I experimented with the hardware identity layer since it’s a core part of the system.

This PR introduces a small standalone Rust module (`rust-identity`) that generates a deterministic device fingerprint. The goal is for this to eventually replace parts of `hardware_identity.py`.

---

### Key decisions

- **Keccak256 (EVM-aligned hashing)**  
  Switched from SHA-256 to `tiny-keccak` to stay consistent with EVM standards

- **Graceful fallback**  
  Reads from `/proc/cpuinfo`, but avoids panicking if access is restricted

- **Easy integration (non-breaking)**  
  Outputs JSON to stdout → can be integrated with the current Python app via a subprocess without major changes

---

### Next steps (optional)

- Explore **PyO3** to integrate Rust directly into Python and eliminate subprocess overhead

---

### Dev note

This is an isolated PoC (separate directory, no changes to existing flows), so it should not affect existing setups or require Rust for other contributors.

---

### Feedback

Would appreciate your thoughts on whether this direction makes sense.

 Closes #49 