### PR TITLE
chore(build): setup aarch64 cross-compilation environment

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+image = "lensmint-cross-aarch64:local"

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,18 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
+
+# Enable multi-arch pkg-config for Rust aarch64 cross-compilation
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+# Add target architecture and install required UI dependencies (X11/Wayland/EGL)
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    pkg-config \
+    libx11-dev:arm64 \
+    libwayland-dev:arm64 \
+    libxkbcommon-dev:arm64 \
+    libegl1-mesa-dev:arm64 \
+    libgl1-mesa-dev:arm64 \
+    libfontconfig1-dev:arm64 \
+    libudev-dev:arm64


### PR DESCRIPTION
Adds cross-compilation config for aarch64 targets.
Fixes pkg-config linking for X11/Wayland/EGL graphical dependencies on x86 hosts.
Tested locally on WSL.

Closes #54 