### PR TITLE
spike(ui): implement event-driven egui static layout

### DIFF
--- a/rust-camera-daemon/lensmint-ui-spike/Cargo.toml
+++ b/rust-camera-daemon/lensmint-ui-spike/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "lensmint-ui-spike"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eframe = "0.27.2"

--- a/rust-camera-daemon/lensmint-ui-spike/Cross.toml
+++ b/rust-camera-daemon/lensmint-ui-spike/Cross.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+image = "lensmint-cross-aarch64:local"

--- a/rust-camera-daemon/lensmint-ui-spike/Dockerfile.cross
+++ b/rust-camera-daemon/lensmint-ui-spike/Dockerfile.cross
@@ -1,0 +1,18 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
+
+# Enable multi-arch pkg-config for Rust aarch64 cross-compilation
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+# Add target architecture and install required UI dependencies (X11/Wayland/EGL)
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    pkg-config \
+    libx11-dev:arm64 \
+    libwayland-dev:arm64 \
+    libxkbcommon-dev:arm64 \
+    libegl1-mesa-dev:arm64 \
+    libgl1-mesa-dev:arm64 \
+    libfontconfig1-dev:arm64 \
+    libudev-dev:arm64

--- a/rust-camera-daemon/lensmint-ui-spike/src/main.rs
+++ b/rust-camera-daemon/lensmint-ui-spike/src/main.rs
@@ -1,0 +1,58 @@
+use eframe::egui;
+
+fn main() -> Result<(), eframe::Error> {
+    // Slightly enlarge viewport to fit the new split layout, keeping embedded aspect ratio.
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([640.0, 480.0]),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "LensMint Static UI",
+        options,
+        Box::new(|_cc| Box::new(SpikeApp::default())),
+    )
+}
+
+#[derive(Default)]
+struct SpikeApp {}
+
+impl eframe::App for SpikeApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // 1. Bottom Status Bar
+        egui::TopBottomPanel::bottom("status_bar").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Device Identity: [Pending Phase 1]");
+                // Right-aligned status indicator
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label("Status: Ready");
+                });
+            });
+        });
+
+        // 2. Right Control Panel
+        egui::SidePanel::right("control_panel").min_width(120.0).show(ctx, |ui| {
+            ui.vertical_centered(|ui| {
+                ui.add_space(50.0);
+                // Prominent capture button
+                let capture_btn = egui::Button::new("Capture").min_size(egui::vec2(100.0, 50.0));
+                if ui.add(capture_btn).clicked() {
+                    println!("Capture button clicked. (Logic pending Week 1)");
+                }
+            });
+        });
+
+        // 3. Central Preview Area
+        egui::CentralPanel::default().show(ctx, |ui| {
+            // Render a dark gray background to simulate camera feed placeholder
+            let rect = ui.available_rect_before_wrap();
+            ui.painter().rect_filled(rect, 0.0, egui::Color32::from_rgb(50, 50, 50));
+            
+            ui.centered_and_justified(|ui| {
+                ui.heading("Camera Preview Placeholder");
+            });
+        });
+        
+        // Note: Event-driven only. No ctx.request_repaint() prevents CPU lockup on embedded aarch64.
+    }
+}


### PR DESCRIPTION
Implements base static layout via pure Rust `eframe` (viewfinder placeholder, capture button).
Uses event-driven mode (omitted `ctx.request_repaint()`) to eliminate CPU overhead during idle on the SBC.

Closes #56 