### PR TITLE
feat: multichain deployment script & Foundry keystores migration

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,0 +1,28 @@
+# RPC URLs
+# For each network you intend to deploy to, add its RPC URL here:
+# Use naming convention: <NETWORK_ID>_RPC_URL
+# The multichain script automatically converts IDs to uppercase, e.g. sepolia -> SEPOLIA_RPC_URL
+SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+POLYGON_AMOY_RPC_URL=https://polygon-amoy.g.alchemy.com/v2/YOUR_API_KEY
+MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+
+# Explorer API Keys (for verification)
+# For each network, add its explorer API key if you want to verify contracts.
+# Use naming convention: <NETWORK_ID>_ETHERSCAN_KEY
+ETHERSCAN_API_KEY=YOUR_ETHERSCAN_KEY
+POLYGONSCAN_API_KEY=YOUR_POLYGONSCAN_KEY
+
+# Deployment configuration
+# Note: PRIVATE_KEY is NOT required in .env. It is recommended to use Foundry keystore.
+# To import a key: cast wallet import <account_name> --interactive
+# Then deploy using: ./deployMultichain.sh --account <account_name> --networks sepolia
+
+# Optional: Set a baseline URI for metadata
+BASE_URI=https://ipfs.io/ipfs/
+
+# Verifier Configuration (Required ONLY if deploying the verifier explicitly)
+# ZK_PROVER_GUEST_ID=0x...
+# NOTARY_KEY_FINGERPRINT=0x...
+# QUERIES_HASH=0x...
+# EXPECTED_URL=https://api.example.com/data
+# RISC_ZERO_VERIFIER_ADDRESS=0x... (Optional if using an existing verifier contract)

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -7,22 +7,21 @@ import {LensMintERC1155} from "../src/LensMintERC1155.sol";
 
 contract DeployScript is Script {
     function run() external {
-        // Load deployer private key from environment
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        // Automatically detected by Forge via --account or --sender
+        address deployer = msg.sender;
         
         console.log("Deploying contracts...");
         console.log("Deployer address:", deployer);
         console.log("Deployer balance:", deployer.balance);
 
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
 
         console.log("\nDeploying DeviceRegistry...");
         DeviceRegistry deviceRegistry = new DeviceRegistry();
         console.log("DeviceRegistry deployed at:", address(deviceRegistry));
 
         console.log("\nDeploying LensMintERC1155...");
-        string memory baseURI = "https://ipfs.io/ipfs/";
+        string memory baseURI = vm.envOr("BASE_URI", string("https://ipfs.io/ipfs/"));
         LensMintERC1155 lensMint = new LensMintERC1155(
             address(deviceRegistry),
             baseURI

--- a/contracts/script/DeployAndVerify.s.sol
+++ b/contracts/script/DeployAndVerify.s.sol
@@ -7,10 +7,9 @@ import {LensMintERC1155} from "../src/LensMintERC1155.sol";
 
 contract DeployAndVerifyScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        address deployer = msg.sender;
         
-        string memory network = vm.envString("NETWORK");
+        string memory network = vm.envOr("NETWORK", string("unknown"));
         string memory baseURI = vm.envOr("BASE_URI", string("https://ipfs.io/ipfs/"));
         
         console.log("=== Deployment Configuration ===");
@@ -20,7 +19,7 @@ contract DeployAndVerifyScript is Script {
         console.log("Base URI:", baseURI);
         console.log("");
 
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
 
         console.log("Deploying DeviceRegistry...");
         DeviceRegistry deviceRegistry = new DeviceRegistry();

--- a/contracts/script/DeployLensMintVerifier.s.sol
+++ b/contracts/script/DeployLensMintVerifier.s.sol
@@ -7,14 +7,13 @@ import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.0/test/RiscZeroMock
 
 contract DeployLensMintVerifierScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        address deployer = msg.sender;
         
         console.log("=== Deploying LensMintVerifier ===");
         console.log("Deployer:", deployer);
         console.log("Balance:", deployer.balance);
         
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
         
         console.log("\nDeploying RiscZeroMockVerifier...");
         RiscZeroMockVerifier mockVerifier = new RiscZeroMockVerifier(0xFFFFFFFF);

--- a/contracts/script/DeployVerifier.s.sol
+++ b/contracts/script/DeployVerifier.s.sol
@@ -7,10 +7,10 @@ import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.0/test/RiscZeroMock
 
 contract DeployVerifierScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        // Automatically detected by Forge via --account or --sender
+        address deployer = msg.sender;
         
-        string memory network = vm.envString("NETWORK");
+        string memory network = vm.envOr("NETWORK", string("unknown"));
         address riscZeroVerifierAddress = vm.envOr("RISC_ZERO_VERIFIER_ADDRESS", address(0));
         
         bytes32 imageId = vm.envBytes32("ZK_PROVER_GUEST_ID");
@@ -28,7 +28,7 @@ contract DeployVerifierScript is Script {
         console.log("Expected URL:", expectedUrl);
         console.log("");
         
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
         
         address verifierAddress;
         if (riscZeroVerifierAddress != address(0)) {

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -1,0 +1,91 @@
+# LensMint Camera - Deployment and Utility Scripts Guide
+
+This directory contains automation scripts for deploying and interacting with the LensMint Camera smart contracts. All scripts utilize the Foundry framework for secure and efficient blockchain interactions.
+
+## Multichain Deployment Pipeline
+
+The core deployment tool is the `deployMultichain.sh` shell script. It orchestrates deployments across multiple EVM-compatible chains while ensuring security by leveraging Foundry Keystores rather than plaintext private keys in .env files.
+
+### 1. Secure Keystore Setup
+
+Before running deployments, you should import your private key into a Foundry Keystore. This encrypts the key on your local machine and requires a password to unlock during script execution.
+
+```bash
+# Import your private key into a named account
+cast wallet import <account_name> --interactive
+```
+
+### 2. Network Configuration
+
+The deployment script references environment variables for RPC URLs. Configure these in your `contracts/.env` file following the standard naming convention:
+
+```env
+# Pattern: <NETWORK_ID>_RPC_URL
+SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+POLYGON_AMOY_RPC_URL=https://polygon-amoy.g.alchemy.com/v2/YOUR_API_KEY
+
+# Explorer API keys for contract verification
+ETHERSCAN_API_KEY=YOUR_ETHERSCAN_KEY
+```
+
+### 3. Executing Deployment
+
+You can deploy to single or multiple networks using the multichain script. The --account flag corresponds to the name you provided during the keystore import.
+
+```bash
+# Deploy to a single network
+./script/deployMultichain.sh --networks sepolia --account <account_name>
+
+# Deploy to multiple networks
+./script/deployMultichain.sh --networks sepolia,polygon_amoy --account <account_name>
+
+# Deploy core contracts along with the LensMint Verifier
+./script/deployMultichain.sh --networks sepolia --account <account_name> --deploy-verifier
+```
+
+---
+
+## Script Reference
+
+| Script | Functionality | Usage Example |
+| :--- | :--- | :--- |
+| deployMultichain.sh | Orchestrates deployment across multiple chains | --networks, --account |
+| Deploy.s.sol | Standard deployment for DeviceRegistry and LensMintERC1155 | forge script script/Deploy.s.sol |
+| DeployVerifier.s.sol | Deploys the verification logic contracts | forge script script/DeployVerifier.s.sol |
+| DeployAndVerify.s.sol | Deployment script with integrated manual verification | Inherits from Deploy.s.sol |
+| SubmitProof.s.sol | Utility for submitting ZK-proofs for verification | forge script script/SubmitProof.s.sol |
+| RegisterDevice.s.sol | Manually registers a device in the central registry | forge script script/RegisterDevice.s.sol |
+
+---
+
+## Utility Scripts Configuration
+
+Utility scripts such as `RegisterDevice.s.sol` and `SubmitProof.s.sol` depend on specific environment variables for execution.
+
+### RegisterDevice.s.sol
+This script enables the contract owner to manually onboard new devices.
+- DEVICE_REGISTRY_ADDRESS: Address of the deployed registry.
+- DEVICE_ADDRESS: The unique address assigned to the hardware device.
+- DEVICE_PUBLIC_KEY: The public key associated with the device's secure enclave.
+- DEVICE_ID, CAMERA_ID, DEVICE_MODEL, FIRMWARE_VERSION: Metadata for registration.
+
+### SubmitProof.s.sol
+This script submits a ZK-proof for verification by the LensMintVerifier contract.
+- VERIFIER_CONTRACT_ADDRESS: Address of the deployed verifier.
+- PROOF_FILE: Filesystem path to the JSON proof artifact.
+
+---
+
+## Customization and Best Practices
+
+### Adding New Networks
+To support a new chain, add the corresponding <NETWORK>_RPC_URL to your .env file and include the network name in the --networks argument of the multichain script.
+
+### Passing Extra Forge Flags
+The `deployMultichain.sh` script passes additional arguments directly to the underlying forge command. This allows you to use flags like:
+- --verify: Automates contract verification on block explorers.
+- --slow: Useful for networks with high congestion to prevent nonce issues.
+
+### Security and Logs
+- Ensure private keys are never committed to version control.
+- Foundry creates deployment logs in the `broadcast/` directory. These are useful for audit trails but should be reviewed before sharing as they may contain environment-specific metadata.

--- a/contracts/script/RegisterDevice.s.sol
+++ b/contracts/script/RegisterDevice.s.sol
@@ -6,8 +6,7 @@ import {DeviceRegistry} from "../src/DeviceRegistry.sol";
 
 contract RegisterDeviceScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        address deployer = msg.sender;
         
         address deviceRegistryAddress = vm.envAddress("DEVICE_REGISTRY_ADDRESS");
         DeviceRegistry deviceRegistry = DeviceRegistry(deviceRegistryAddress);
@@ -25,7 +24,7 @@ contract RegisterDeviceScript is Script {
         console.log("Camera ID:", cameraId);
         console.log("Model:", model);
 
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
 
         deviceRegistry.registerDevice(
             deviceAddress,

--- a/contracts/script/SubmitProof.s.sol
+++ b/contracts/script/SubmitProof.s.sol
@@ -6,8 +6,7 @@ import {LensMintVerifier} from "../src/LensMintVerifier.sol";
 
 contract SubmitProofScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.addr(deployerPrivateKey);
+        address deployer = msg.sender;
         
         address verifierAddress = vm.envAddress("VERIFIER_CONTRACT_ADDRESS");
         string memory proofFilePath = vm.envString("PROOF_FILE");
@@ -19,7 +18,7 @@ contract SubmitProofScript is Script {
         
         string memory proofJson = vm.readFile(proofFilePath);
         
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
         
         LensMintVerifier verifier = LensMintVerifier(verifierAddress);
         

--- a/contracts/script/deployMultichain.sh
+++ b/contracts/script/deployMultichain.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# ==============================================================================
+# Script: deployMultichain.sh
+# Documentation: 
+#   Automates deployment across multiple EVM-compatible networks using Foundry.
+#   Uses Foundry Keystores (--account) to avoid storing private keys in .env.
+# 
+# Usage:
+#   ./deployMultichain.sh --networks sepolia,polygon --account my-account
+#   ./deployMultichain.sh --networks sepolia --account my-account --deploy-verifier
+# ==============================================================================
+
+# Exit the script if any command fails
+set -e
+
+# 1. Load variables from .env file if it exists safely
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+# 2. Argument Parsing
+TARGET_NETWORKS=""
+DEPLOY_VERIFIER=false
+FORGE_PASS_THROUGH_FLAGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --networks)
+            TARGET_NETWORKS="$2"
+            shift 2
+            ;;
+        --deploy-verifier)
+            DEPLOY_VERIFIER=true
+            shift
+            ;;
+        *)
+            # Collect all other flags (like --account, --keystore, --verify)
+            FORGE_PASS_THROUGH_FLAGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Basic validation
+if [ -z "$TARGET_NETWORKS" ]; then
+    echo "Error: Missing mandatory argument --networks."
+    echo "Usage: ./deployMultichain.sh --networks <sepolia,polygon> --account <your-acc>"
+    exit 1
+fi
+
+# 3. Deployment Pipeline
+# Split the comma-separated network names into an array
+IFS=',' read -ra NETWORK_LIST <<< "$TARGET_NETWORKS"
+
+for network_name in "${NETWORK_LIST[@]}"; do
+    echo "----------------------------------------------------"
+    echo "Processing Network: $network_name"
+    echo "----------------------------------------------------"
+
+    # Auto-generate RPC variable name (e.g., SEPOLIA_RPC_URL)
+    # Using posix compatible upper-casing logic
+    NETWORK_UPPER=$(echo "$network_name" | tr '[:lower:]' '[:upper:]')
+    RPC_VAR_NAME="${NETWORK_UPPER}_RPC_URL"
+    RPC_URL="${!RPC_VAR_NAME}"
+
+    if [ -z "$RPC_URL" ]; then
+        echo "Warning: RPC URL not found for $network_name ($RPC_VAR_NAME). Skipping..."
+        continue
+    fi
+
+    echo "RPC URL found: $RPC_URL"
+    echo "Executing standard Forge Deployment Script..."
+
+    # Use array for pass through flags to prevent splitting issues
+    NETWORK_ENV="NETWORK=$network_name"
+    
+    # Deploy Registry and LensMint
+    env $NETWORK_ENV forge script script/Deploy.s.sol \
+        --rpc-url "$RPC_URL" \
+        --broadcast \
+        "${FORGE_PASS_THROUGH_FLAGS[@]}"
+    
+    # Optionally Deploy the Verifier
+    if [ "$DEPLOY_VERIFIER" = true ]; then
+        echo "Executing Verifier Deployment Script (--deploy-verifier enabled)..."
+        env $NETWORK_ENV forge script script/DeployVerifier.s.sol \
+            --rpc-url "$RPC_URL" \
+            --broadcast \
+            "${FORGE_PASS_THROUGH_FLAGS[@]}"
+    fi
+    
+    echo "Done with $network_name."
+    echo ""
+done
+
+echo "Global deployment sequence completed successfully."


### PR DESCRIPTION
I noticed that as the project scales, managing plaintext private keys in `.env` could become a security risk, and deploying to multiple chains needed a more unified approach. So, I revamped the deployment setup to make it safer and smoother for everyone. 

### What changed? :D
- **Security Upgrade:** Migrated away from plaintext `.env` keys to **Foundry keystores** (ERC-2335). Deployer keys are now heavily encrypted.
- **Multichain Support:** Added a unified multichain deployment script along with a new `.env.example` template.
- **Documentation:** Included a comprehensive guide so anyone can jump into the new keystore flow easily.

### Checklist
- [x] Code compiles successfully.
- [x] Tested the new deployment scripts locally.
- [x] Documentation updated.