### PR TITLE
test: expand mint gate and verifier coverage

### DIFF
--- a/contracts/test/AuthenticityVerifierEdgeCases.t.sol
+++ b/contracts/test/AuthenticityVerifierEdgeCases.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {AuthenticityVerifier} from "../src/AuthenticityVerifier.sol";
+import {IRiscZeroVerifier, Receipt as RiscZeroReceipt} from "risc0-risc0-ethereum-3.0.0/IRiscZeroVerifier.sol";
+import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.0/test/RiscZeroMockVerifier.sol";
+
+contract AuthenticityVerifierEdgeCasesTest is Test {
+    bytes4 internal constant MOCK_SELECTOR = bytes4(0xffffffff);
+    bytes32 internal constant IMAGE_ID = bytes32(uint256(0xA11CE));
+    bytes32 internal constant ALG = bytes32("sha256+gradient-phash-v1");
+
+    RiscZeroMockVerifier internal mock;
+    AuthenticityVerifier internal auth;
+
+    function setUp() public {
+        mock = new RiscZeroMockVerifier(MOCK_SELECTOR);
+        auth = new AuthenticityVerifier(address(mock), IMAGE_ID, ALG);
+    }
+
+    function _journal(uint32 distance, uint32 threshold, bytes32 alg) internal pure returns (bytes memory) {
+        return abi.encode(
+            bytes32(uint256(0x1111)),
+            bytes32(bytes8(0x0d1a34489032468c)),
+            bytes32(bytes8(0x0d1a34489032468d)),
+            bytes32(uint256(0x2222)),
+            distance,
+            threshold,
+            alg
+        );
+    }
+
+    function _mockSeal(bytes32 imageId, bytes memory journal) internal view returns (bytes memory) {
+        RiscZeroReceipt memory receipt = mock.mockProve(imageId, sha256(journal));
+        return receipt.seal;
+    }
+
+    function test_bad_journal_length_reverts() public {
+        vm.expectRevert(AuthenticityVerifier.BadJournalLength.selector);
+        auth.verifyAuthenticity("", new bytes(223));
+
+        vm.expectRevert(AuthenticityVerifier.BadJournalLength.selector);
+        auth.verifyAuthenticity("", new bytes(225));
+    }
+
+    function test_bad_algorithm_reverts() public {
+        bytes memory journal = _journal(1, 5, bytes32("wrong-alg"));
+        bytes memory seal = _mockSeal(IMAGE_ID, journal);
+
+        vm.expectRevert(AuthenticityVerifier.BadAlg.selector);
+        auth.verifyAuthenticity(seal, journal);
+    }
+
+    function test_distance_at_threshold_succeeds() public {
+        bytes memory journal = _journal(5, 5, ALG);
+        bytes memory seal = _mockSeal(IMAGE_ID, journal);
+
+        auth.verifyAuthenticity(seal, journal);
+
+        bytes32 digest = sha256(journal);
+        (,,,, uint32 storedDistance, uint32 storedThreshold,, bool verified) = auth.claimsByJournalDigest(digest);
+        assertEq(storedDistance, 5);
+        assertEq(storedThreshold, 5);
+        assertTrue(verified);
+    }
+
+    function test_distance_over_threshold_reverts() public {
+        bytes memory journal = _journal(6, 5, ALG);
+        bytes memory seal = _mockSeal(IMAGE_ID, journal);
+
+        vm.expectRevert(AuthenticityVerifier.DistanceTooLarge.selector);
+        auth.verifyAuthenticity(seal, journal);
+    }
+
+    function test_wrong_image_id_seal_reverts() public {
+        bytes memory journal = _journal(1, 5, ALG);
+        bytes memory seal = _mockSeal(bytes32(uint256(0xB0B)), journal);
+
+        vm.expectRevert(AuthenticityVerifier.ZKProofVerificationFailed.selector);
+        auth.verifyAuthenticity(seal, journal);
+    }
+
+    function test_verifier_receives_image_id_and_journal_digest() public {
+        bytes memory journal = _journal(1, 5, ALG);
+        bytes memory seal = _mockSeal(IMAGE_ID, journal);
+
+        vm.expectCall(address(mock), abi.encodeCall(IRiscZeroVerifier.verify, (seal, IMAGE_ID, sha256(journal))));
+        auth.verifyAuthenticity(seal, journal);
+    }
+}

--- a/lensmint-zk/core/tests/journal_abi_contract.rs
+++ b/lensmint-zk/core/tests/journal_abi_contract.rs
@@ -1,0 +1,89 @@
+use lensmint_zk_core::{GuestError, GuestJournal, HASH_ALG, JOURNAL_ABI_LEN};
+
+const SHA256_HEX: &str = "e8e12e6a5f63658efb1766cdec4bd3f56400baf7200f2936710a8027a043676c";
+const PHASH0_HEX: &str = "0d1a34489032468c";
+const PHASH1_HEX: &str = "0d1a34489032468d";
+const PUBKEY_HEX: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+fn fixture_journal() -> GuestJournal {
+    GuestJournal {
+        device_pubkey_hex: PUBKEY_HEX.to_string(),
+        phash0_hex: PHASH0_HEX.to_string(),
+        phash1_hex: PHASH1_HEX.to_string(),
+        distance: 1,
+        threshold: 5,
+        sha256_hex: SHA256_HEX.to_string(),
+        alg: HASH_ALG.to_string(),
+    }
+}
+
+#[test]
+fn journal_matches_solidity_static_abi_layout() {
+    let encoded = fixture_journal().abi_encode().expect("encode journal");
+
+    assert_eq!(encoded.len(), JOURNAL_ABI_LEN);
+    assert_eq!(&encoded[0..32], hex::decode(SHA256_HEX).unwrap());
+    assert_eq!(&encoded[32..40], hex::decode(PHASH0_HEX).unwrap());
+    assert_eq!(&encoded[40..64], &[0; 24]);
+    assert_eq!(&encoded[64..72], hex::decode(PHASH1_HEX).unwrap());
+    assert_eq!(&encoded[72..96], &[0; 24]);
+    assert_eq!(&encoded[96..128], hex::decode(PUBKEY_HEX).unwrap());
+    assert_eq!(&encoded[128..156], &[0; 28]);
+    assert_eq!(&encoded[156..160], &1u32.to_be_bytes());
+    assert_eq!(&encoded[160..188], &[0; 28]);
+    assert_eq!(&encoded[188..192], &5u32.to_be_bytes());
+    assert_eq!(&encoded[192..192 + HASH_ALG.len()], HASH_ALG.as_bytes());
+    assert!(encoded[192 + HASH_ALG.len()..224]
+        .iter()
+        .all(|byte| *byte == 0));
+
+    assert_eq!(
+        GuestJournal::from_abi(&encoded).expect("decode journal"),
+        fixture_journal()
+    );
+}
+
+#[test]
+fn decode_rejects_non_224_byte_journals() {
+    for len in [JOURNAL_ABI_LEN - 1, JOURNAL_ABI_LEN + 1] {
+        let err = GuestJournal::from_abi(&vec![0; len]).expect_err("bad length must fail");
+        assert!(matches!(
+            err,
+            GuestError::BadLen {
+                field: "journal_abi",
+                expected: JOURNAL_ABI_LEN,
+                got
+            } if got == len
+        ));
+    }
+}
+
+#[test]
+fn decode_rejects_nonzero_phash_padding() {
+    let mut encoded = fixture_journal().abi_encode().expect("encode journal");
+    encoded[40] = 1;
+
+    let err = GuestJournal::from_abi(&encoded).expect_err("dirty padding must fail");
+
+    assert_eq!(err, GuestError::BadHex("phash_padding"));
+}
+
+#[test]
+fn decode_rejects_wrong_algorithm_word() {
+    let mut encoded = fixture_journal().abi_encode().expect("encode journal");
+    encoded[192] ^= 1;
+
+    let err = GuestJournal::from_abi(&encoded).expect_err("wrong alg must fail");
+
+    assert_eq!(err, GuestError::BadHex("alg"));
+}
+
+#[test]
+fn encode_rejects_unknown_algorithm() {
+    let mut journal = fixture_journal();
+    journal.alg = "sha256+unknown-phash".to_string();
+
+    let err = journal.abi_encode().expect_err("wrong alg must fail");
+
+    assert_eq!(err, GuestError::BadHex("alg"));
+}

--- a/rust-camera-daemon/lensmint-daemon/src/config.rs
+++ b/rust-camera-daemon/lensmint-daemon/src/config.rs
@@ -77,3 +77,7 @@ pub fn load_solana_rpcs() -> SolanaRpcConfig {
     let raw = read_config("solana_rpcs.json", EMBEDDED_SOLANA_RPCS);
     serde_json::from_str(&raw).expect("Invalid solana_rpcs.json")
 }
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/rust-camera-daemon/lensmint-daemon/src/config_tests.rs
+++ b/rust-camera-daemon/lensmint-daemon/src/config_tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+#[test]
+fn embedded_contracts_include_sepolia_mint_contract() {
+    let config: ContractsConfig =
+        serde_json::from_str(EMBEDDED_CONTRACTS).expect("parse embedded contracts");
+    let sepolia = config.evm(11_155_111).expect("Sepolia config");
+
+    assert_eq!(sepolia.name, "Sepolia");
+    assert_eq!(
+        sepolia.lensmint,
+        "0x263E52714bb8A80C98d08A7fC541e9Ae1d6C96cC"
+    );
+}
+
+#[test]
+fn embedded_contracts_include_solana_devnet_programs() {
+    let config: ContractsConfig =
+        serde_json::from_str(EMBEDDED_CONTRACTS).expect("parse embedded contracts");
+    let devnet = config.solana("devnet").expect("Solana devnet config");
+
+    assert_eq!(
+        devnet.program_id,
+        "Cco1bP778KAZNR5uLCRgmt3iFQ3cjGudyiMcnTJ7X1nW"
+    );
+    assert_eq!(
+        devnet.mpl_core,
+        "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d"
+    );
+}
+
+#[test]
+fn embedded_solana_rpc_lists_cover_each_ui_cluster() {
+    let config: SolanaRpcConfig =
+        serde_json::from_str(EMBEDDED_SOLANA_RPCS).expect("parse embedded Solana RPCs");
+
+    for cluster in ["devnet", "testnet", "mainnet"] {
+        let urls = config
+            .get(cluster)
+            .unwrap_or_else(|| panic!("{cluster} RPC list"));
+        assert!(!urls.is_empty(), "{cluster} RPC list must not be empty");
+        assert!(
+            urls.iter().all(|url| url.starts_with("https://")),
+            "{cluster} RPCs must use HTTPS"
+        );
+    }
+}

--- a/rust-camera-daemon/lensmint-daemon/src/proof_gate.rs
+++ b/rust-camera-daemon/lensmint-daemon/src/proof_gate.rs
@@ -275,3 +275,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+
+#[cfg(test)]
+#[path = "proof_gate_gap_tests.rs"]
+mod proof_gate_gap_tests;

--- a/rust-camera-daemon/lensmint-daemon/src/proof_gate_gap_tests.rs
+++ b/rust-camera-daemon/lensmint-daemon/src/proof_gate_gap_tests.rs
@@ -1,0 +1,146 @@
+use super::*;
+use crate::keystore::LocalKeystore;
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use std::path::{Path, PathBuf};
+
+struct CaptureFixture {
+    dir: PathBuf,
+    uuid: uuid::Uuid,
+    record: HashRecord,
+}
+
+impl CaptureFixture {
+    fn new() -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("lensmint-proof-gate-gaps-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create fixture directory");
+
+        let keystore = LocalKeystore {
+            signing_key: SigningKey::generate(&mut OsRng),
+        };
+        let uuid = uuid::Uuid::new_v4();
+        let jpeg = tiny_jpeg();
+        let record =
+            HashRecord::create_from_jpeg_bytes(uuid, &jpeg, &keystore).expect("create record");
+        record.save(&dir).expect("save record");
+        std::fs::write(receipt_path(&dir, &uuid), b"non-empty-receipt").expect("write receipt");
+
+        Self { dir, uuid, record }
+    }
+
+    fn write_journal(&self, journal: &JournalFile) {
+        std::fs::write(
+            journal_path(&self.dir, &self.uuid),
+            serde_json::to_vec_pretty(journal).expect("serialize journal"),
+        )
+        .expect("write journal");
+    }
+
+    fn matching_journal(&self) -> JournalFile {
+        JournalFile {
+            device_pubkey_hex: self.record.device_pubkey.clone(),
+            phash0_hex: self.record.phash.clone(),
+            phash1_hex: self.record.phash.clone(),
+            distance: 0,
+            threshold: 5,
+            sha256_hex: self.record.sha256.clone(),
+            alg: self.record.alg.clone(),
+        }
+    }
+}
+
+impl Drop for CaptureFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn tiny_jpeg() -> Vec<u8> {
+    let img = image::RgbaImage::from_pixel(8, 8, image::Rgba([10, 20, 30, 255]));
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut cursor, image::ImageFormat::Jpeg)
+        .expect("encode jpeg");
+    cursor.into_inner()
+}
+
+fn write_raw_journal(dir: &Path, uuid: &uuid::Uuid, bytes: &[u8]) {
+    std::fs::write(journal_path(dir, uuid), bytes).expect("write raw journal");
+}
+
+#[test]
+fn missing_journal_blocks_mint() {
+    let fixture = CaptureFixture::new();
+
+    let err = require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect_err("missing journal must block");
+
+    assert!(err.contains("missing journal"), "{err}");
+}
+
+#[test]
+fn mismatched_phash_blocks_mint() {
+    let fixture = CaptureFixture::new();
+    let mut journal = fixture.matching_journal();
+    journal.phash0_hex = "ff".repeat(8);
+    if journal.phash0_hex == fixture.record.phash {
+        journal.phash0_hex = "00".repeat(8);
+    }
+    fixture.write_journal(&journal);
+
+    let err = require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect_err("mismatched phash must block");
+
+    assert!(err.contains("phash"), "{err}");
+}
+
+#[test]
+fn mismatched_device_pubkey_blocks_mint() {
+    let fixture = CaptureFixture::new();
+    let mut journal = fixture.matching_journal();
+    journal.device_pubkey_hex = "00".repeat(32);
+    fixture.write_journal(&journal);
+
+    let err = require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect_err("mismatched pubkey must block");
+
+    assert!(err.contains("pubkey"), "{err}");
+}
+
+#[test]
+fn invalid_journal_json_blocks_mint() {
+    let fixture = CaptureFixture::new();
+    write_raw_journal(&fixture.dir, &fixture.uuid, b"{not-json");
+
+    let err = require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect_err("invalid journal must block");
+
+    assert!(err.contains("invalid journal"), "{err}");
+}
+
+#[test]
+fn invalid_hash_record_signature_blocks_mint() {
+    let fixture = CaptureFixture::new();
+    let mut record = fixture.record.clone();
+    record.signature = "00".repeat(64);
+    record.save(&fixture.dir).expect("overwrite record");
+    fixture.write_journal(&fixture.matching_journal());
+
+    let err = require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect_err("invalid record signature must block");
+
+    assert!(err.contains("signature invalid"), "{err}");
+}
+
+#[test]
+fn local_gate_does_not_recheck_distance_or_alg() {
+    let fixture = CaptureFixture::new();
+    let mut journal = fixture.matching_journal();
+    journal.distance = 99;
+    journal.threshold = 0;
+    journal.alg = "not-the-real-alg".to_string();
+    fixture.write_journal(&journal);
+
+    require_proof_for_mint(&fixture.dir, &fixture.uuid)
+        .expect("gate matches sha256, phash0, and pubkey only");
+}


### PR DESCRIPTION
Adds tests for the mint gate, journal ABI, and AuthenticityVerifier. Runtime code is unchanged except `#[cfg(test)]` wiring.

The repo already had unit tests for the happy paths. This PR adds the missing failure cases and ABI checks:

- mint gate: missing journal, phash/pubkey mismatch, invalid JSON, bad HashRecord signature. Also locks the current behavior that the gate does not recheck distance or alg.
- embedded Sepolia and Solana config still parses
- Rust 224-byte journal matches Solidity `abi.encode`
- verifier errors: bad journal length, bad alg, distance 5 vs 6, wrong IMAGE_ID, and the `verify(seal, IMAGE_ID, journalDigest)` call

```bash
cargo test --manifest-path rust-camera-daemon/lensmint-daemon/Cargo.toml
cargo test --manifest-path lensmint-zk/Cargo.toml -p lensmint-zk-core -p host
forge test --root contracts